### PR TITLE
feat: Secrets Manager Authentication

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ set(SRC
   src/authentication/adfs/adfs.cc
   src/authentication/authentication_provider.cc
   src/authentication/federation.cc
+  src/authentication/secrets_manager_helper.cc
 
   src/failover/cluster_topology_info.cc
 
@@ -51,6 +52,7 @@ set(INC
   src/authentication/adfs/adfs.h
   src/authentication/authentication_provider.h
   src/authentication/federation.h
+  src/authentication/secrets_manager_helper.h
 
   src/failover/cluster_topology_info.h
 
@@ -127,6 +129,7 @@ set(
   "aws-cpp-sdk-core"
   "aws-cpp-sdk-sts"
   "aws-cpp-sdk-rds"
+  "aws-cpp-sdk-secretsmanager"
 )
 set(AWS_SDK_LIBRARIES_EXPANDED "")
 foreach(lib ${AWS_SDK_LIBS})

--- a/src/authentication/authentication_provider.h
+++ b/src/authentication/authentication_provider.h
@@ -30,6 +30,10 @@
 #ifndef __AUTHENTICATION_PROVIDER_H__
 #define __AUTHENTICATION_PROVIDER_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // TODO - Limits here are based on PgSQL
 #define LARGE_REGISTRY_LEN          4096
 #define MEDIUM_REGISTRY_LEN         1024
@@ -66,15 +70,20 @@ typedef struct {
     char ssl_insecure[SMALL_REGISTRY_LEN];
 } FederatedAuthConfig;
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+typedef struct Credentials {
+    char *username;
+    char *password;
+    unsigned int username_size;
+    unsigned int password_size;
+} Credentials;
 
 FederatedAuthType GetFedAuthTypeEnum(const char *str);
 
-bool GetCachedToken(char* token, const int maxSize, const char* dbHostName, const char* dbRegion, const char* port, const char* dbUserName);
+bool GetCachedToken(char* token, const unsigned int maxSize, const char* dbHostName, const char* dbRegion, const char* port, const char* dbUserName);
 void UpdateCachedToken(const char* dbHostName, const char* dbRegion, const char* port, const char* dbUserName, const char* token, const char* expirationTime);
-bool GenerateConnectAuthToken(char* token, const int maxSize, const char* dbHostName, const char* dbRegion, unsigned port, const char* dbUserName, FederatedAuthType type, FederatedAuthConfig config);
+bool GenerateConnectAuthToken(char* token, const unsigned int maxSize, const char* dbHostName, const char* dbRegion, unsigned port, const char* dbUserName, FederatedAuthType type, FederatedAuthConfig config);
+
+bool GetCredentialsFromSecretsManager(const char *secretId, const char *region, Credentials *credentials);
 
 #ifdef __cplusplus
 }

--- a/src/authentication/secrets_manager_helper.cc
+++ b/src/authentication/secrets_manager_helper.cc
@@ -1,0 +1,84 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License, version 2.0
+// (GPLv2), as published by the Free Software Foundation, with the
+// following additional permissions:
+//
+// This program is distributed with certain software that is licensed
+// under separate terms, as designated in a particular file or component
+// or in the license documentation. Without limiting your rights under
+// the GPLv2, the authors of this program hereby grant you an additional
+// permission to link the program and your derivative works with the
+// separately licensed software that they have included with the program.
+//
+// Without limiting the foregoing grant of rights under the GPLv2 and
+// additional permission as to separately licensed software, this
+// program is also subject to the Universal FOSS Exception, version 1.0,
+// a copy of which can be found along with its FAQ at
+// http://oss.oracle.com/licenses/universal-foss-exception.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see 
+// http://www.gnu.org/licenses/gpl-2.0.html.
+
+#include <regex>
+#include <cstdlib>
+#include <cstring>
+
+#include <aws/core/Aws.h>
+#include <aws/core/utils/json/JsonSerializer.h>
+#include <aws/secretsmanager/SecretsManagerServiceClientModel.h>
+#include <aws/secretsmanager/model/GetSecretValueRequest.h>
+
+#include "secrets_manager_helper.h"
+#include "authentication_provider.h"
+#include "../util/logger_wrapper.h"
+
+namespace {
+    const Aws::String USERNAME_KEY{ "username" };
+    const Aws::String PASSWORD_KEY{ "password" };
+    const std::string SECRETS_ARN_PATTERN{ "arn:aws:secretsmanager:([-a-zA-Z0-9]+):.*" };
+}
+
+bool SECRETS_MANAGER_HELPER::TryParseRegionFromSecretId(Aws::String secretId, Aws::String& region) {
+    std::regex rgx(SECRETS_ARN_PATTERN);
+    std::smatch matches;
+
+    if (std::regex_search(secretId, matches, rgx) && matches.size() > 1) {
+        region = matches[1].str();
+        return true;
+    }
+
+    return false;
+}
+
+bool SECRETS_MANAGER_HELPER::FetchCredentials(Aws::String secretId) {
+    Aws::SecretsManager::Model::GetSecretValueRequest request;
+    request.SetSecretId(secretId);
+
+    const Aws::SecretsManager::Model::GetSecretValueOutcome outcome = this->smClient->GetSecretValue(request);
+
+    if (outcome.IsSuccess()) {
+        const Aws::String secretJsonStr = outcome.GetResult().GetSecretString();
+        const Aws::Utils::Json::JsonValue secretJson = Aws::Utils::Json::JsonValue(secretJsonStr);
+        const Aws::Utils::Json::JsonView view = secretJson.View();
+
+        if (view.ValueExists(USERNAME_KEY) && view.ValueExists(PASSWORD_KEY)) {
+            username = view.GetString(USERNAME_KEY);
+            password = view.GetString(PASSWORD_KEY);
+
+            return true;
+        }
+
+        return false;
+    } else {
+        LOG(ERROR) << "Error getting secret value: " << outcome.GetError().GetMessage();
+        return false;
+    }
+}

--- a/src/authentication/secrets_manager_helper.h
+++ b/src/authentication/secrets_manager_helper.h
@@ -1,0 +1,58 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License, version 2.0
+// (GPLv2), as published by the Free Software Foundation, with the
+// following additional permissions:
+//
+// This program is distributed with certain software that is licensed
+// under separate terms, as designated in a particular file or component
+// or in the license documentation. Without limiting your rights under
+// the GPLv2, the authors of this program hereby grant you an additional
+// permission to link the program and your derivative works with the
+// separately licensed software that they have included with the program.
+//
+// Without limiting the foregoing grant of rights under the GPLv2 and
+// additional permission as to separately licensed software, this
+// program is also subject to the Universal FOSS Exception, version 1.0,
+// a copy of which can be found along with its FAQ at
+// http://oss.oracle.com/licenses/universal-foss-exception.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see 
+// http://www.gnu.org/licenses/gpl-2.0.html.
+
+#ifndef __SECRETSMANAGERHELPER_H__
+#define __SECRETSMANAGERHELPER_H__
+
+#include <aws/secretsmanager/SecretsManagerClient.h>
+
+class SECRETS_MANAGER_HELPER {
+    public:
+        SECRETS_MANAGER_HELPER(std::shared_ptr<Aws::SecretsManager::SecretsManagerClient> smClient)
+            : smClient(smClient) {}
+        ~SECRETS_MANAGER_HELPER() {}
+
+        // attempts to match secret_ID to a secrets ARN regex and parses the region portion; returns true if parsed, false if not
+        static bool TryParseRegionFromSecretId(Aws::String secretId, Aws::String& region);
+
+        // fetches credentials from the configured secrets manager client and stored the retrieved values into username and password
+        bool FetchCredentials(Aws::String secretId);
+
+        // get the fetched username
+        Aws::String GetUsername() { return this->username; }
+
+        // get the fetched password
+        Aws::String GetPassword() { return this->password; }
+    private:
+        std::shared_ptr<Aws::SecretsManager::SecretsManagerClient> smClient;
+        Aws::String username;
+        Aws::String password;
+};
+
+#endif

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -35,6 +35,7 @@ add_executable(
 
   authentication/authentication_provider_test.cc
   authentication/adfs/adfs_test.cc
+  authentication/secrets_manager_helper_test.cc
 
   failover/cluster_topology_info_test.cc
 

--- a/test/unit_test/authentication/secrets_manager_helper_test.cc
+++ b/test/unit_test/authentication/secrets_manager_helper_test.cc
@@ -1,0 +1,114 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License, version 2.0
+// (GPLv2), as published by the Free Software Foundation, with the
+// following additional permissions:
+//
+// This program is distributed with certain software that is licensed
+// under separate terms, as designated in a particular file or component
+// or in the license documentation. Without limiting your rights under
+// the GPLv2, the authors of this program hereby grant you an additional
+// permission to link the program and your derivative works with the
+// separately licensed software that they have included with the program.
+//
+// Without limiting the foregoing grant of rights under the GPLv2 and
+// additional permission as to separately licensed software, this
+// program is also subject to the Universal FOSS Exception, version 1.0,
+// a copy of which can be found along with its FAQ at
+// http://oss.oracle.com/licenses/universal-foss-exception.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see 
+// http://www.gnu.org/licenses/gpl-2.0.html.
+
+#include <cstdio>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "../mock_objects.h"
+
+#include <aws/core/Aws.h>
+#include <aws/secretsmanager/SecretsManagerClient.h>
+#include <aws/secretsmanager/model/GetSecretValueRequest.h>
+
+#include "secrets_manager_helper.h"
+#include "logger_wrapper.h"
+
+using testing::Property;
+using testing::Return;
+using testing::StrEq;
+
+namespace {
+    const Aws::String TEST_SECRET_ID{"secret_ID"};
+    const Aws::String TEST_REGION{"us-east-2"};
+    const Aws::String TEST_USERNAME{"test-user"};
+    const Aws::String TEST_PASSWORD{"test-password"};
+    const auto TEST_SECRET_STRING = R"({"username": ")" + TEST_USERNAME + R"(", "password": ")" + TEST_PASSWORD + R"("})";
+    const auto TEST_SECRET = Aws::Utils::Json::JsonValue(TEST_SECRET_STRING);
+}
+
+Aws::SDKOptions testSdkOptions;
+
+class SecretsManagerHelperTest : public testing::Test {
+  protected:
+    std::shared_ptr<MOCK_SECRETS_MANAGER_CLIENT> mockSmClient;
+
+    // Runs once per suite
+    static void SetUpTestSuite() {
+      Aws::InitAPI(testSdkOptions);
+    }
+    static void TearDownTestSuite() {
+      Aws::ShutdownAPI(testSdkOptions);
+    }
+
+    // Runs per test case
+    void SetUp() override {
+      mockSmClient = std::make_shared<MOCK_SECRETS_MANAGER_CLIENT>();
+    }
+    void TearDown() override {}
+};
+
+TEST_F(SecretsManagerHelperTest, FetchCredentialsOK) {
+  const Aws::SecretsManager::Model::GetSecretValueResult result = Aws::SecretsManager::Model::GetSecretValueResult().WithSecretString(TEST_SECRET_STRING);
+  const Aws::SecretsManager::Model::GetSecretValueOutcome successfulOutcome = Aws::SecretsManager::Model::GetSecretValueOutcome(result);
+
+  EXPECT_CALL(*mockSmClient, GetSecretValue(
+    Property("GetSecretId", &Aws::SecretsManager::Model::GetSecretValueRequest::GetSecretId, StrEq(TEST_SECRET_ID))
+  )).WillOnce(Return(successfulOutcome));
+
+  SECRETS_MANAGER_HELPER smHelper(mockSmClient);
+
+  bool res = smHelper.FetchCredentials(TEST_SECRET_ID);
+  EXPECT_TRUE(res);
+  EXPECT_EQ(smHelper.GetUsername(), TEST_USERNAME);
+  EXPECT_EQ(smHelper.GetPassword(), TEST_PASSWORD);
+}
+
+TEST_F(SecretsManagerHelperTest, FetchCredentialsError) {
+  const Aws::SecretsManager::Model::GetSecretValueOutcome erroredOutcome = Aws::SecretsManager::Model::GetSecretValueOutcome();
+
+  EXPECT_CALL(*mockSmClient, GetSecretValue(
+    Property("GetSecretId", &Aws::SecretsManager::Model::GetSecretValueRequest::GetSecretId, StrEq(TEST_SECRET_ID))
+  )).WillOnce(Return(erroredOutcome));
+
+  SECRETS_MANAGER_HELPER smHelper(mockSmClient);
+
+  bool res = smHelper.FetchCredentials(TEST_SECRET_ID);
+  EXPECT_FALSE(res);
+}
+
+TEST_F(SecretsManagerHelperTest, TryParseRegionFromSecretIdOK) {
+  Aws::String secretIdWithRegion = "arn:aws:secretsmanager:us-east-2:otherthings";
+  Aws::String region = "";
+
+  bool res = SECRETS_MANAGER_HELPER::TryParseRegionFromSecretId(secretIdWithRegion, region);
+  EXPECT_TRUE(res);
+  EXPECT_EQ(region, "us-east-2");
+}

--- a/test/unit_test/mock_objects.h
+++ b/test/unit_test/mock_objects.h
@@ -32,7 +32,18 @@
 
 #include <gmock/gmock.h>
 
+#include <aws/secretsmanager/SecretsManagerClient.h>
+#include <aws/secretsmanager/model/GetSecretValueRequest.h>
+
 #include "federation.h"
+#include "authentication_provider.h"
+
+class MOCK_SECRETS_MANAGER_CLIENT : public Aws::SecretsManager::SecretsManagerClient {
+public:
+    MOCK_SECRETS_MANAGER_CLIENT() : SecretsManagerClient() {};
+
+    MOCK_METHOD(Aws::SecretsManager::Model::GetSecretValueOutcome, GetSecretValue, (const Aws::SecretsManager::Model::GetSecretValueRequest&), (const));
+};
 
 // Note that we inherit from the real class and mock only virtual functions.
 


### PR DESCRIPTION
# Summary
Method to fetch credentials from AWS Secrets Manager

## Description
Exports SECRETS_MANAGER_HELPER class (C++) and GetCredentialsFromSecretsManager_Lib (C).

## Testing
- [x] Unit tests for SECRETS_MANAGER_HELPER pass
- [x] Other unit tests pass
- [x] Analyzer passes
- [x] Driver can call this function to retrieve credentials from AWS secrets manager
