### PR TITLE
fix: import stdbool for C & parse error check

### DIFF
--- a/src/authentication/authentication_provider.cc
+++ b/src/authentication/authentication_provider.cc
@@ -89,6 +89,14 @@ static bool ValidateOktaConf(FederatedAuthConfig config) {
         ValidateCharArr(config.idp_password);
 }
 
+static uint64_t ParseNumber(const char* str_in, const uint64_t default_val) {
+    try {
+        return atol(str_in);
+    } catch (std::exception& e) {
+        return default_val;
+    }
+}
+
 static Aws::RDS::RDSClient* CreateRDSClient(FederatedAuthType type, FederatedAuthConfig config) {
     Aws::Auth::AWSCredentials credentials;
     switch (type) {
@@ -100,8 +108,8 @@ static Aws::RDS::RDSClient* CreateRDSClient(FederatedAuthType type, FederatedAut
                 return nullptr;
             };
             Aws::Client::ClientConfiguration http_client_cfg;
-            http_client_cfg.requestTimeoutMs = config.http_client_socket_timeout ? atol(config.http_client_socket_timeout) : 3000;
-            http_client_cfg.connectTimeoutMs = config.http_client_connect_timeout ? atol(config.http_client_connect_timeout) : 5000;
+            http_client_cfg.requestTimeoutMs = ParseNumber(config.http_client_socket_timeout, 3000);
+            http_client_cfg.connectTimeoutMs = ParseNumber(config.http_client_connect_timeout, 5000);
             http_client_cfg.verifySSL = true;
             std::shared_ptr<Aws::Http::HttpClient> http_client = Aws::Http::CreateHttpClient(http_client_cfg);
             std::shared_ptr<Aws::STS::STSClient> sts_client = std::make_shared<Aws::STS::STSClient>();
@@ -125,8 +133,8 @@ static Aws::RDS::RDSClient* CreateRDSClient(FederatedAuthType type, FederatedAut
                 return nullptr;
             };
             Aws::Client::ClientConfiguration http_client_cfg;
-            http_client_cfg.requestTimeoutMs = config.http_client_socket_timeout ? atol(config.http_client_socket_timeout) : 3000;
-            http_client_cfg.connectTimeoutMs = config.http_client_connect_timeout ? atol(config.http_client_connect_timeout) : 5000;
+            http_client_cfg.requestTimeoutMs = ParseNumber(config.http_client_socket_timeout, 3000);
+            http_client_cfg.connectTimeoutMs = ParseNumber(config.http_client_connect_timeout, 5000);
             http_client_cfg.verifySSL = true;
             http_client_cfg.followRedirects = Aws::Client::FollowRedirectsPolicy::ALWAYS;
             std::shared_ptr<Aws::Http::HttpClient> http_client = Aws::Http::CreateHttpClient(http_client_cfg);

--- a/src/authentication/authentication_provider.h
+++ b/src/authentication/authentication_provider.h
@@ -34,6 +34,8 @@
 extern "C" {
 #endif
 
+#include <stdbool.h>
+
 // TODO(yuenhcol) - Limits here are based on PgSQL
 #define LARGE_REGISTRY_LEN          4096
 #define MEDIUM_REGISTRY_LEN         1024

--- a/src/authentication/html_util.cc
+++ b/src/authentication/html_util.cc
@@ -35,7 +35,7 @@
 #endif
 
 namespace HtmlUtil {
-    std::string HtmlUtil::escape_html_entity(const std::string& html) {
+    std::string escape_html_entity(const std::string& html) {
         std::string retval;
         DLOG(INFO) << "Before HTML escape modification: " << html;
         int i = 0;


### PR DESCRIPTION
# Summary
Adds `stdbool` & Error Handling for parsing ints from strings

## Description
- Adding `stdbool` to `authentication_provider.h` to allow C to understand bools. This is mainly for MacOS not understanding bool
- Using try/catch to parse numbers in the scenario where the driver is passed a non-valid integer and also fixes warning of "always true".
- Minor change to fix warnings on extra qualifier

## Testing
TBD, trying on Mac
