### PR TITLE
Changes to allow `aws-rds-odbc` to build inside the `aws-pgsql-odbc` Dockerized test container

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,10 +24,14 @@
 # 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 ##########################################################################
 
-cmake_minimum_required(VERSION 3.30 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
 project("aws-rds-odbc")
 set(CMAKE_CXX_STANDARD 20)
-set(BUILD_SHARED_LIBS OFF CACHE INTERNAL "Build as static libraries")
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  set(BUILD_SHARED_LIBS ON CACHE INTERNAL "Build as shared library")
+else()
+  set(BUILD_SHARED_LIBS OFF CACHE INTERNAL "Build as static library")
+endif()  
 
 #-----------------------------------------------------
 
@@ -78,7 +82,11 @@ set(INC
   src/util/odbc_helper.h
 )
 
-add_library(${PROJECT_NAME} STATIC ${SRC} ${INC})
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  add_library(${PROJECT_NAME} SHARED ${SRC} ${INC})
+else()
+  add_library(${PROJECT_NAME} STATIC ${SRC} ${INC})
+endif()
 include_directories(${CMAKE_SOURCE_DIR})
 include_directories("${CMAKE_SOURCE_DIR}/src")
 include_directories("${CMAKE_SOURCE_DIR}/src/authentication")
@@ -153,9 +161,10 @@ set(
   "aws-cpp-sdk-rds"
   "aws-cpp-sdk-secretsmanager"
 )
+
 set(AWS_SDK_LIBRARIES_EXPANDED "")
 foreach(lib ${AWS_SDK_LIBS})
-  if(APPLE)
+  if(APPLE OR CMAKE_SYSTEM_NAME STREQUAL "Linux")
     list(APPEND AWS_SDK_LIBRARIES_EXPANDED ${AWS_SDK_DIR}/lib/lib${lib}.a)
   endif()
   if(WIN32)

--- a/src/util/logger_wrapper.h
+++ b/src/util/logger_wrapper.h
@@ -37,8 +37,6 @@
 #endif /* XCODE_BUILD */
 
 #include <glog/logging.h>
-
-#include <format>
 #include <filesystem>
 
 namespace logger_config {

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(unit_test)
 
-cmake_minimum_required(VERSION 3.30 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
 set(CMAKE_CXX_STANDARD 20)
 
 #-----------------------------------------------------


### PR DESCRIPTION
# Summary

This changes are required to allow this library to build as part of the `linux/buildall` script inside `aws-pgsql-odbc`.

## Testing

Automated CI testing will verify the changes.