### PR TITLE
fix: style check on headers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,6 +7,7 @@ Checks: >
   performance-*,
   portability-*,
   readability-*,
+  llvm-include-order,
   -google-readability-braces-around-statements,
   -google-readability-namespace-comments,
   -google-runtime-references,
@@ -20,12 +21,12 @@ Checks: >
   -modernize-concat-nested-namespaces,
   -modernize-use-nodiscard,
   -modernize-avoid-c-arrays,
+  -modernize-use-using,
   -performance-move-const-arg,
   -performance-avoid-endl,
   -performance-enum-size,
   -readability-braces-around-statements,
   -readability-identifier-length,
-  -readability-magic-numbers,
   -readability-named-parameter,
   -readability-redundant-declaration,
   -readability-avoid-return-with-void-value,
@@ -41,7 +42,11 @@ Checks: >
 # Turn all the warnings from the checks above into errors.
 WarningsAsErrors: "*"
 
-HeaderFilterRegex: ""
+HeaderFilterRegex: "aws-rds-odbc/(build|src).*\\.h$"
+# Skip checking dependencies
+ExcludeHeaderFilterRegex: "(_deps|aws_sdk)"
+InheritParentConfig: false
+SystemHeaders: false
 
 CheckOptions:
   - { key: readability-identifier-naming.NamespaceCase,                 value: lower_case }
@@ -52,9 +57,6 @@ CheckOptions:
   - { key: readability-identifier-naming.FunctionCase,                  value: aNy_CasE   }
   - { key: readability-identifier-naming.VariableCase,                  value: lower_case }
   - { key: readability-identifier-naming.ClassMemberCase,               value: lower_case }
-  - { key: readability-identifier-naming.ClassMemberSuffix,             value: _          }
-  - { key: readability-identifier-naming.PrivateMemberSuffix,           value: _          }
-  - { key: readability-identifier-naming.ProtectedMemberSuffix,         value: _          }
   - { key: readability-identifier-naming.EnumConstantCase,              value: UPPER_CASE }
   - { key: readability-identifier-naming.ConstexprVariableCase,         value: UPPER_CASE }
   - { key: readability-identifier-naming.GlobalConstantCase,            value: UPPER_CASE }

--- a/.gitignore
+++ b/.gitignore
@@ -442,6 +442,7 @@ aws_sdk/
 
 # Build output directory
 build
+cmake-build-debug
 
 # CodeChecker static analysis reports directory
 reports

--- a/src/authentication/adfs/adfs.cc
+++ b/src/authentication/adfs/adfs.cc
@@ -28,11 +28,12 @@
 // http://www.gnu.org/licenses/gpl-2.0.html.
 
 #include "adfs.h"
-#include "../html_util.h"
-#include "../util/logger_wrapper.h"
 
 #include <regex>
 #include <unordered_set>
+
+#include "../html_util.h"
+#include "../util/logger_wrapper.h"
 
 const std::string AdfsCredentialsProvider::FORM_ACTION_PATTERN = "<form.*?action=\"([^\"]+)\"";
 const std::string AdfsCredentialsProvider::SAML_RESPONSE_PATTERN = "SAMLResponse\\W+value=\"(.*)\"( />)";

--- a/src/authentication/adfs/adfs.h
+++ b/src/authentication/adfs/adfs.h
@@ -27,14 +27,14 @@
 // along with this program. If not, see 
 // http://www.gnu.org/licenses/gpl-2.0.html.
 
-#ifndef __ADFS_H__
-#define __ADFS_H__
-
-#include "../authentication_provider.h"
-#include "../federation.h"
+#ifndef ADFS_H_
+#define ADFS_H_
 
 #include <map>
 #include <string>
+
+#include "../authentication_provider.h"
+#include "../federation.h"
 
 class AdfsCredentialsProvider : public FederationCredentialProvider {
 public:
@@ -42,7 +42,9 @@ public:
         const FederatedAuthConfig& config,
         std::shared_ptr<Aws::Http::HttpClient> http_client,
         std::shared_ptr<Aws::STS::STSClient> sts_client
-    ): FederationCredentialProvider(config.iam_idp_arn, config.iam_role_arn, http_client, sts_client), cfg(config) {}
+    ): FederationCredentialProvider(
+            config.iam_idp_arn, config.iam_role_arn, std::move(http_client), std::move(sts_client)
+        ), cfg(config) {}
 
     // constant pattern strings 
     static const std::string FORM_ACTION_PATTERN;
@@ -51,7 +53,7 @@ public:
     static const std::string INPUT_TAG_PATTERN;
 
 protected:
-    virtual std::string GetSAMLAssertion(std::string& err_info);
+    std::string GetSAMLAssertion(std::string& err_info) override;
 
 private:
     std::string get_signin_url();
@@ -65,4 +67,4 @@ private:
     FederatedAuthConfig cfg;
 };
 
-#endif  //__ADFS_H__
+#endif // ADFS_H_

--- a/src/authentication/authentication_provider.h
+++ b/src/authentication/authentication_provider.h
@@ -27,8 +27,8 @@
 // along with this program. If not, see 
 // http://www.gnu.org/licenses/gpl-2.0.html.
 
-#ifndef __AUTHENTICATION_PROVIDER_H__
-#define __AUTHENTICATION_PROVIDER_H__
+#ifndef AUTHENTICATION_PROVIDER_H_
+#define AUTHENTICATION_PROVIDER_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -55,7 +55,7 @@ typedef enum {
     FOREACH_AUTHTYPE(GENERATE_ENUM)
 } FederatedAuthType;
 
-static const char* FEDERATED_AUTH_TYPE_STRING[] = {
+static const char* federated_auth_type_str[] = {
     FOREACH_AUTHTYPE(GENERATE_STRING)
 };
 
@@ -82,9 +82,9 @@ typedef struct Credentials {
 
 FederatedAuthType GetFedAuthTypeEnum(const char *str);
 
-bool GetCachedToken(char* token, const unsigned int max_size, const char* db_hostname, const char* db_region, const char* port, const char* db_user);
+bool GetCachedToken(char* token, unsigned int max_size, const char* db_hostname, const char* db_region, const char* port, const char* db_user);
 void UpdateCachedToken(const char* db_hostname, const char* db_region, const char* port, const char* db_user, const char* token, const char* expiration_time);
-bool GenerateConnectAuthToken(char* token, const unsigned int max_size, const char* db_hostname, const char* db_region, unsigned port, const char* db_user, FederatedAuthType type, FederatedAuthConfig config);
+bool GenerateConnectAuthToken(char* token, unsigned int max_size, const char* db_hostname, const char* db_region, unsigned port, const char* db_user, FederatedAuthType type, FederatedAuthConfig config);
 
 bool GetCredentialsFromSecretsManager(const char* secret_id, const char* region, Credentials* credentials);
 
@@ -92,4 +92,4 @@ bool GetCredentialsFromSecretsManager(const char* secret_id, const char* region,
 }
 #endif
 
-#endif  //__AUTHENTICATION_PROVIDER_H__
+#endif // AUTHENTICATION_PROVIDER_H_

--- a/src/authentication/federation.h
+++ b/src/authentication/federation.h
@@ -27,20 +27,21 @@
 // along with this program. If not, see 
 // http://www.gnu.org/licenses/gpl-2.0.html.
 
-#ifndef __FEDERATION_H__
-#define __FEDERATION_H__
+#ifndef FEDERATION_H_
+#define FEDERATION_H_
 
 #include <aws/core/Aws.h>
 #include <aws/core/auth/AWSCredentials.h>
 #include <aws/core/http/HttpClient.h>
-#include <aws/sts/model/AssumeRoleWithSAMLRequest.h>
 #include <aws/sts/STSClient.h>
+#include <aws/sts/model/AssumeRoleWithSAMLRequest.h>
 
 class FederationCredentialProvider {
 public:
-    FederationCredentialProvider(const std::string& idp_arn, const std::string& role_arn,
+    FederationCredentialProvider(std::string idp_arn, std::string role_arn,
         std::shared_ptr<Aws::Http::HttpClient> http_client, std::shared_ptr<Aws::STS::STSClient> sts_client)
-        : idp_arn(idp_arn), role_arn(role_arn), http_client(http_client), sts_client(sts_client) {}
+        : idp_arn(std::move(idp_arn)), role_arn(std::move(role_arn)),
+        http_client(std::move(http_client)), sts_client(std::move(sts_client)) {}
 
     bool GetAWSCredentials(Aws::Auth::AWSCredentials& credentials);
 
@@ -56,4 +57,4 @@ protected:
     std::shared_ptr<Aws::STS::STSClient> sts_client;
 };
 
-#endif  //__FEDERATION_H__
+#endif // FEDERATION_H_

--- a/src/authentication/html_util.h
+++ b/src/authentication/html_util.h
@@ -27,13 +27,17 @@
 // along with this program. If not, see 
 // http://www.gnu.org/licenses/gpl-2.0.html.
 
-#ifndef __HTML_UTIL_H__
-#define __HTML_UTIL_H__
+#ifndef HTML_UTIL_H_
+#define HTML_UTIL_H_
 
 #include <string>
+#include <unordered_map>
 
-namespace HtmlUtil {
-    std::string escape_html_entity(const std::string& html);
+class HtmlUtil {
+public:
+    static std::string escape_html_entity(const std::string& html);
+private:
+    static const std::unordered_map<std::string, char> HTML_DECODE_MAP;
 };
 
-#endif  //__HTML_UTIL_H__
+#endif // HTML_UTIL_H_

--- a/src/authentication/okta/okta.cc
+++ b/src/authentication/okta/okta.cc
@@ -28,12 +28,12 @@
 // http://www.gnu.org/licenses/gpl-2.0.html.
 
 #include "okta.h"
-#include "../html_util.h"
-
-#include "../util/logger_wrapper.h"
 
 #include <regex>
 #include <unordered_set>
+
+#include "../html_util.h"
+#include "../util/logger_wrapper.h"
 
 const std::string OktaCredentialsProvider::SAML_RESPONSE_PATTERN = "<input name=\"SAMLResponse\".+value=\"(.+)\"/\\>";
 

--- a/src/authentication/okta/okta.h
+++ b/src/authentication/okta/okta.h
@@ -27,14 +27,14 @@
 // along with this program. If not, see 
 // http://www.gnu.org/licenses/gpl-2.0.html.
 
-#ifndef __OKTA_H__
-#define __OKTA_H__
-
-#include "../authentication_provider.h"
-#include "../federation.h"
+#ifndef OKTA_H_
+#define OKTA_H_
 
 #include <map>
 #include <string>
+
+#include "../authentication_provider.h"
+#include "../federation.h"
 
 class OktaCredentialsProvider : public FederationCredentialProvider {
 public:
@@ -42,13 +42,15 @@ public:
         const FederatedAuthConfig& config,
         std::shared_ptr<Aws::Http::HttpClient> http_client,
         std::shared_ptr<Aws::STS::STSClient> sts_client
-    ): FederationCredentialProvider(config.iam_idp_arn, config.iam_role_arn, http_client, sts_client), cfg(config) {}
+    ): FederationCredentialProvider(
+            config.iam_idp_arn, config.iam_role_arn, std::move(http_client), std::move(sts_client)
+        ), cfg(config) {}
 
     // constant pattern strings 
     static const std::string SAML_RESPONSE_PATTERN;
 
 protected:
-    virtual std::string GetSAMLAssertion(std::string& err_info);
+    std::string GetSAMLAssertion(std::string& err_info) override;
 
 private:
     std::string get_session_token();
@@ -58,4 +60,4 @@ private:
     FederatedAuthConfig cfg;
 };
 
-#endif  //__OKTA_H__
+#endif // OKTA_H_

--- a/src/authentication/secrets_manager_helper.cc
+++ b/src/authentication/secrets_manager_helper.cc
@@ -27,18 +27,19 @@
 // along with this program. If not, see
 // http://www.gnu.org/licenses/gpl-2.0.html.
 
+#include "secrets_manager_helper.h"
+
 #include <cstdlib>
 #include <cstring>
 #include <regex>
 
 #include <aws/core/Aws.h>
 #include <aws/core/utils/json/JsonSerializer.h>
-#include <aws/secretsmanager/model/GetSecretValueRequest.h>
 #include <aws/secretsmanager/SecretsManagerServiceClientModel.h>
+#include <aws/secretsmanager/model/GetSecretValueRequest.h>
 
-#include "authentication_provider.h"
-#include "secrets_manager_helper.h"
 #include "../util/logger_wrapper.h"
+#include "authentication_provider.h"
 
 namespace {
     const Aws::String USERNAME_KEY{ "username" };
@@ -46,7 +47,7 @@ namespace {
     const std::string SECRETS_ARN_PATTERN{ "arn:aws:secretsmanager:([-a-zA-Z0-9]+):.*" };
 }
 
-bool SECRETS_MANAGER_HELPER::TryParseRegionFromSecretId(const Aws::String& secret_id, Aws::String& region) {
+bool SecretsManagerHelper::TryParseRegionFromSecretId(const Aws::String& secret_id, Aws::String& region) {
     std::regex rgx(SECRETS_ARN_PATTERN);
     std::smatch matches;
 
@@ -58,7 +59,7 @@ bool SECRETS_MANAGER_HELPER::TryParseRegionFromSecretId(const Aws::String& secre
     return false;
 }
 
-bool SECRETS_MANAGER_HELPER::FetchCredentials(const Aws::String& secret_id) {
+bool SecretsManagerHelper::FetchCredentials(const Aws::String& secret_id) {
     Aws::SecretsManager::Model::GetSecretValueRequest request;
     request.SetSecretId(secret_id);
 

--- a/src/authentication/secrets_manager_helper.h
+++ b/src/authentication/secrets_manager_helper.h
@@ -27,16 +27,16 @@
 // along with this program. If not, see 
 // http://www.gnu.org/licenses/gpl-2.0.html.
 
-#ifndef __SECRETSMANAGERHELPER_H__
-#define __SECRETSMANAGERHELPER_H__
+#ifndef SECRETSMANAGERHELPER_H_
+#define SECRETSMANAGERHELPER_H_
 
 #include <aws/secretsmanager/SecretsManagerClient.h>
 
-class SECRETS_MANAGER_HELPER {
+class SecretsManagerHelper {
     public:
-        SECRETS_MANAGER_HELPER(std::shared_ptr<Aws::SecretsManager::SecretsManagerClient> sm_client)
-            : sm_client(sm_client) {}
-        ~SECRETS_MANAGER_HELPER() {}
+        explicit SecretsManagerHelper(std::shared_ptr<Aws::SecretsManager::SecretsManagerClient> sm_client)
+            : sm_client(std::move(sm_client)) {}
+        ~SecretsManagerHelper() = default;
 
         // attempts to match secret_ID to a secrets ARN regex and parses the region portion; returns true if parsed, false if not
         static bool TryParseRegionFromSecretId(const Aws::String& secret_id, Aws::String& region);
@@ -55,4 +55,4 @@ class SECRETS_MANAGER_HELPER {
         Aws::String password;
 };
 
-#endif
+#endif // SECRETSMANAGERHELPER_H_

--- a/src/failover/cluster_topology_info.h
+++ b/src/failover/cluster_topology_info.h
@@ -27,16 +27,16 @@
 // along with this program. If not, see 
 // http://www.gnu.org/licenses/gpl-2.0.html.
 
-#ifndef __CLUSTERTOPOLOGYINFO_H__
-#define __CLUSTERTOPOLOGYINFO_H__
+#ifndef CLUSTERTOPOLOGYINFO_H_
+#define CLUSTERTOPOLOGYINFO_H_
 
 #include "host_info.h"
-
-#include "../util/logger_wrapper.h"
 
 #include <ctime>
 #include <set>
 #include <vector>
+
+#include "../util/logger_wrapper.h"
 
 // This class holds topology information for one cluster.
 // Cluster topology consists of an instance endpoint, a set of nodes in the cluster,
@@ -84,4 +84,4 @@ private:
     friend class TOPOLOGY_SERVICE;
 };
 
-#endif /* __CLUSTERTOPOLOGYINFO_H__ */
+#endif // CLUSTERTOPOLOGYINFO_H_

--- a/src/host_availability/host_availability_strategy.h
+++ b/src/host_availability/host_availability_strategy.h
@@ -27,8 +27,8 @@
 // along with this program. If not, see 
 // http://www.gnu.org/licenses/gpl-2.0.html.
 
-#ifndef __HOSTAVAILABILITYSTRATEGY_H__
-#define __HOSTAVAILABILITYSTRATEGY_H__
+#ifndef HOSTAVAILABILITYSTRATEGY_H_
+#define HOSTAVAILABILITYSTRATEGY_H_
 
 typedef enum {
   AVAILABLE,
@@ -43,4 +43,4 @@ public:
     virtual HostAvailability get_host_availability(HostAvailability rawHostAvailability) = 0;
 };
 
-#endif /* __HOSTAVAILABILITYSTRATEGY_H__ */
+#endif // HOSTAVAILABILITYSTRATEGY_H_

--- a/src/host_availability/simple_host_availability_strategy.h
+++ b/src/host_availability/simple_host_availability_strategy.h
@@ -27,8 +27,8 @@
 // along with this program. If not, see 
 // http://www.gnu.org/licenses/gpl-2.0.html.
 
-#ifndef __SIMPLEHOSTAVAILABILITYSTRATEGY_H__
-#define __SIMPLEHOSTAVAILABILITYSTRATEGY_H__
+#ifndef SIMPLEHOSTAVAILABILITYSTRATEGY_H_
+#define SIMPLEHOSTAVAILABILITYSTRATEGY_H_
 
 #include "host_availability_strategy.h"
 
@@ -38,4 +38,4 @@ public:
     HostAvailability get_host_availability(HostAvailability rawHostAvailability) override;
 };
 
-#endif /* __SIMPLEHOSTAVAILABILITYSTRATEGY_H__ */
+#endif // SIMPLEHOSTAVAILABILITYSTRATEGY_H_

--- a/src/host_info.cc
+++ b/src/host_info.cc
@@ -72,7 +72,7 @@ uint64_t HostInfo::get_weight() const {
  * @return the host:port representation of this host
  */
 std::string HostInfo::get_host_port_pair() const {
-    return get_host() + HOST_PORT_SEPARATOR + std::to_string(get_port());
+    return get_host() + host_port_separator + std::to_string(get_port());
 }
 
 bool HostInfo::equal_host_port_pair(HostInfo& hi) const {

--- a/src/host_info.h
+++ b/src/host_info.h
@@ -27,14 +27,14 @@
 // along with this program. If not, see
 // http://www.gnu.org/licenses/gpl-2.0.html.
 
-#ifndef __HOSTINFO_H__
-#define __HOSTINFO_H__
-
-#include "logger_wrapper.h"
-#include "host_availability/host_availability_strategy.h"
+#ifndef HOSTINFO_H_
+#define HOSTINFO_H_
 
 #include <memory>
 #include <string>
+
+#include "host_availability/host_availability_strategy.h"
+#include "logger_wrapper.h"
 
 enum HOST_STATE { UP, DOWN };
 
@@ -78,7 +78,7 @@ public:
     std::string replica_lag;
 
 private:
-    std::string HOST_PORT_SEPARATOR = ":";
+    std::string host_port_separator = ":";
     std::string host;
     int port = NO_PORT;
     uint64_t weight = DEFAULT_WEIGHT;
@@ -89,4 +89,4 @@ private:
     std::shared_ptr<HostAvailabilityStrategy> host_availability_strategy;
 };
 
-#endif /* __HOSTINFO_H__ */
+#endif /* HOSTINFO_H_ */

--- a/src/host_selector/host_selector.h
+++ b/src/host_selector/host_selector.h
@@ -27,8 +27,8 @@
 // along with this program. If not, see 
 // http://www.gnu.org/licenses/gpl-2.0.html.
 
-#ifndef __HOST_SELECTOR_H__
-#define __HOST_SELECTOR_H__
+#ifndef HOST_SELECTOR_H_
+#define HOST_SELECTOR_H_
 
 #include "../host_info.h"
 
@@ -43,4 +43,4 @@ public:
         std::unordered_map<std::string, std::string> properties) = 0;
 };
 
-#endif //__HOST_SELECTOR_H__
+#endif // HOST_SELECTOR_H_

--- a/src/host_selector/random_host_selector.h
+++ b/src/host_selector/random_host_selector.h
@@ -27,8 +27,8 @@
 // along with this program. If not, see 
 // http://www.gnu.org/licenses/gpl-2.0.html.
 
-#ifndef __RANDOM_HOST_SELECTOR_H__
-#define __RANDOM_HOST_SELECTOR_H__
+#ifndef RANDOM_HOST_SELECTOR_H_
+#define RANDOM_HOST_SELECTOR_H_
 
 #include "../host_info.h"
 #include "host_selector.h"
@@ -39,4 +39,4 @@ public:
         std::unordered_map<std::string, std::string> properties) override;
 };
 
-#endif //__RANDOM_HOST_SELECTOR_H__
+#endif // RANDOM_HOST_SELECTOR_H_

--- a/src/host_selector/round_robin_host_selector.h
+++ b/src/host_selector/round_robin_host_selector.h
@@ -47,11 +47,11 @@ public:
     static void clear_cache();
 
 private:
-    const int DEFAULT_WEIGHT_ = 1;
-    const int NO_HOST_IDX_ = -1;
+    const int DEFAULT_WEIGHT = 1;
+    const int NO_HOST_IDX = -1;
 
-    static std::mutex cache_mutex_;
-    static CacheMap<std::string, std::shared_ptr<round_robin_property::RoundRobinClusterInfo>> round_robin_cache_;
+    static std::mutex cache_mutex;
+    static CacheMap<std::string, std::shared_ptr<round_robin_property::RoundRobinClusterInfo>> round_robin_cache;
 
     virtual int convert_to_int(const std::string& str);
 

--- a/src/limitless/limitless_query_helper.cc
+++ b/src/limitless/limitless_query_helper.cc
@@ -27,10 +27,11 @@
 // along with this program. If not, see 
 // http://www.gnu.org/licenses/gpl-2.0.html.
 
+#include "limitless_query_helper.h"
+
 #include <cmath>
 #include <string>
 
-#include "limitless_query_helper.h"
 #include "../util/logger_wrapper.h"
 #include "../util/odbc_helper.h"
 
@@ -80,10 +81,10 @@ std::vector<HostInfo> LimitlessQueryHelper::QueryForLimitlessRouters(SQLHDBC con
 }
 
 HostInfo LimitlessQueryHelper::CreateHost(const SQLCHAR* load, const SQLCHAR* router_endpoint, const int host_port_to_map) {
-    int64_t weight = std::round(10.0 - (atof(reinterpret_cast<const char *>(load)) * 10.0));
+    int64_t weight = std::round(WEIGHT_SCALING - (atof(reinterpret_cast<const char *>(load)) * WEIGHT_SCALING));
 
-    if (weight < 1 || weight > 10) {
-        weight = 1;
+    if (weight < MIN_WEIGHT || weight > MAX_WEIGHT) {
+        weight = MIN_WEIGHT;
         LOG(WARNING) << "Invalid router load of " << load << " for " << router_endpoint;
     }
 

--- a/src/limitless/limitless_query_helper.h
+++ b/src/limitless/limitless_query_helper.h
@@ -27,8 +27,8 @@
 // along with this program. If not, see 
 // http://www.gnu.org/licenses/gpl-2.0.html.
 
-#ifndef __LIMITLESSQUERYHELPER_H__
-#define __LIMITLESSQUERYHELPER_H__
+#ifndef LIMITLESSQUERYHELPER_H_
+#define LIMITLESSQUERYHELPER_H_
 
 #ifdef WIN32
 #include <windows.h>
@@ -45,12 +45,15 @@ class LimitlessQueryHelper {
 public:
     static const int ROUTER_ENDPOINT_LENGTH = 2049;
     static const int LOAD_LENGTH = 5;
+    static const int WEIGHT_SCALING = 10;
+    static const int MAX_WEIGHT = 10;
+    static const int MIN_WEIGHT = 1;
     static const std::string LIMITLESS_ROUTER_ENDPOINT_QUERY;
 
-    static std::vector<HostInfo> QueryForLimitlessRouters(SQLHDBC conn, const int host_port_to_map);
+    static std::vector<HostInfo> QueryForLimitlessRouters(SQLHDBC conn, int host_port_to_map);
 
 private:
-    static HostInfo CreateHost(const SQLCHAR* load, const SQLCHAR* router_endpoint, const int host_port_to_map);
+    static HostInfo CreateHost(const SQLCHAR* load, const SQLCHAR* router_endpoint, int host_port_to_map);
 };
 
-#endif /* __LIMITLESSQUERYHELPER_H__ */
+#endif // LIMITLESSQUERYHELPER_H_

--- a/src/util/cache_map.cc
+++ b/src/util/cache_map.cc
@@ -32,26 +32,26 @@
 
 template <typename K, typename V>
 void CacheMap<K, V>::put(const K& key, const V& value) {
-    put(key, value, DEFAULT_EXPIRATION_);
+    put(key, value, DEFAULT_EXPIRATION_SEC);
 }
 
 template <typename K, typename V>
 void CacheMap<K, V>::put(const K& key, const V& value, int sec_ttl) {
-    std::lock_guard<std::mutex> lock(cache_lock_);
+    std::lock_guard<std::mutex> lock(cache_lock);
     std::chrono::steady_clock::time_point expiry_time =
         std::chrono::steady_clock::now() + std::chrono::seconds(sec_ttl);
-    cache_[key] = CacheEntry{value, expiry_time};
+    cache[key] = CacheEntry{value, expiry_time};
 }
 
 template <typename K, typename V>
 V CacheMap<K, V>::get(const K& key) {
     std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
-    if (auto itr = cache_.find(key); itr != cache_.end()) {
+    if (auto itr = cache.find(key); itr != cache.end()) {
         if (itr->second.expiry > now) {
             return itr->second.value;
         }
         // Expired, remove from cache
-        cache_.erase(itr);        
+        cache.erase(itr);        
     }
     return {};
 }
@@ -59,12 +59,12 @@ V CacheMap<K, V>::get(const K& key) {
 template <typename K, typename V>
 bool CacheMap<K, V>::find(const K& key) {
     std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
-    if (auto itr = cache_.find(key); itr != cache_.end()) {
+    if (auto itr = cache.find(key); itr != cache.end()) {
         if (itr->second.expiry > now) {
             return true;
         }
         // Expired, remove from cache
-        cache_.erase(itr);
+        cache.erase(itr);
     }
     return false;
 }
@@ -72,20 +72,20 @@ bool CacheMap<K, V>::find(const K& key) {
 template <typename K, typename V>
 unsigned int CacheMap<K, V>::size() {
     std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
-    for (auto itr = cache_.begin(); itr != cache_.end();) {
+    for (auto itr = cache.begin(); itr != cache.end();) {
         if (itr->second.expiry < now) {
-            itr = cache_.erase(itr);
+            itr = cache.erase(itr);
         } else {
             itr++;
         }
     }
-    return cache_.size();
+    return cache.size();
 }
 
 template <typename K, typename V>
 void CacheMap<K, V>::clear() {
-    std::lock_guard<std::mutex> lock(cache_lock_);
-    cache_.clear();
+    std::lock_guard<std::mutex> lock(cache_lock);
+    cache.clear();
 }
 
 // Explicit Template Instantiations

--- a/src/util/cache_map.h
+++ b/src/util/cache_map.h
@@ -53,9 +53,9 @@ private:
         V value;
         std::chrono::steady_clock::time_point expiry;
     };
-    const int DEFAULT_EXPIRATION_ = 600; // 600s = 10m
-    std::unordered_map<K, CacheEntry> cache_;
-    std::mutex cache_lock_;
+    const int DEFAULT_EXPIRATION_SEC = 600; // 600s = 10m
+    std::unordered_map<K, CacheEntry> cache;
+    std::mutex cache_lock;
 };
 
 #endif // CACHE_MAP_H_

--- a/src/util/logger_wrapper.h
+++ b/src/util/logger_wrapper.h
@@ -27,8 +27,8 @@
 // along with this program. If not, see 
 // http://www.gnu.org/licenses/gpl-2.0.html.
 
-#ifndef __LOGGERWRAPPER_H__
-#define __LOGGERWRAPPER_H__
+#ifndef LOGGERWRAPPER_H_
+#define LOGGERWRAPPER_H_
 
 #ifdef XCODE_BUILD
 // Setting this to a value greater than 3 strips out all of the
@@ -36,8 +36,8 @@
 #define GOOGLE_STRIP_LOG 4
 #endif /* XCODE_BUILD */
 
-#include <glog/logging.h>
 #include <filesystem>
+#include <glog/logging.h>
 
 namespace logger_config {
     const std::string PROGRAM_NAME = "aws-rds-odbc";
@@ -63,4 +63,4 @@ private:
     bool init = false;
 };
 
-#endif /* __LOGGERWRAPPER_H__ */
+#endif // LOGGERWRAPPER_H_

--- a/src/util/odbc_helper.cc
+++ b/src/util/odbc_helper.cc
@@ -43,8 +43,8 @@ bool OdbcHelper::CheckResult(SQLRETURN rc, const std::string& log_message, SQLHA
 }
 
 void OdbcHelper::LogMessage(const std::string& log_message, SQLHANDLE handle, int32_t handle_type) {
-    SQLCHAR     sqlstate[32];
-    SQLCHAR     message[1000];
+    SQLCHAR     sqlstate[MAX_STATE_LENGTH];
+    SQLCHAR     message[MAX_MSG_LENGTH];
     SQLINTEGER	nativeerror;
     SQLSMALLINT textlen;
     SQLRETURN	ret;

--- a/src/util/odbc_helper.h
+++ b/src/util/odbc_helper.h
@@ -27,8 +27,8 @@
 // along with this program. If not, see
 // http://www.gnu.org/licenses/gpl-2.0.html.
 
-#ifndef __ODBCHELPER_H__
-#define __ODBCHELPER_H__
+#ifndef ODBCHELPER_H_
+#define ODBCHELPER_H_
 
 #ifdef WIN32
 #include <windows.h>
@@ -40,10 +40,13 @@
 
 class OdbcHelper {
 public:
+    static const int MAX_STATE_LENGTH = 32;
+    static const int MAX_MSG_LENGTH = 1024;
+
     static bool CheckResult(SQLRETURN rc, const std::string& log_message, SQLHANDLE handle, int32_t handle_type);
 
 private:
     static void LogMessage(const std::string& log_message, SQLHANDLE handle, int32_t handle_type);     
 };
 
-#endif /* __ODBCHELPER_H__ */
+#endif // ODBCHELPER_H_

--- a/test/unit_test/authentication/secrets_manager_helper_test.cc
+++ b/test/unit_test/authentication/secrets_manager_helper_test.cc
@@ -83,7 +83,7 @@ TEST_F(SecretsManagerHelperTest, FetchCredentialsOK) {
     Property("GetSecretId", &Aws::SecretsManager::Model::GetSecretValueRequest::GetSecretId, StrEq(TEST_SECRET_ID))
   )).WillOnce(Return(successfulOutcome));
 
-  SECRETS_MANAGER_HELPER smHelper(mockSmClient);
+  SecretsManagerHelper smHelper(mockSmClient);
 
   bool res = smHelper.FetchCredentials(TEST_SECRET_ID);
   EXPECT_TRUE(res);
@@ -98,7 +98,7 @@ TEST_F(SecretsManagerHelperTest, FetchCredentialsError) {
     Property("GetSecretId", &Aws::SecretsManager::Model::GetSecretValueRequest::GetSecretId, StrEq(TEST_SECRET_ID))
   )).WillOnce(Return(erroredOutcome));
 
-  SECRETS_MANAGER_HELPER smHelper(mockSmClient);
+  SecretsManagerHelper smHelper(mockSmClient);
 
   bool res = smHelper.FetchCredentials(TEST_SECRET_ID);
   EXPECT_FALSE(res);
@@ -108,7 +108,7 @@ TEST_F(SecretsManagerHelperTest, TryParseRegionFromSecretIdOK) {
   Aws::String secretIdWithRegion = "arn:aws:secretsmanager:us-east-2:otherthings";
   Aws::String region = "";
 
-  bool res = SECRETS_MANAGER_HELPER::TryParseRegionFromSecretId(secretIdWithRegion, region);
+  bool res = SecretsManagerHelper::TryParseRegionFromSecretId(secretIdWithRegion, region);
   EXPECT_TRUE(res);
   EXPECT_EQ(region, "us-east-2");
 }


### PR DESCRIPTION
# Summary
Adds Style Check on header files & Fixes

## Description
- Added style checking for headers and Include ordering which is sorted by lexicon if in the same block
- Removed member class suffix style check
- Reordered includes. Top level will be the header file of its own include, e.g. `Class.cc` will have `#include Class.h` at the top. Followed by angle bracket includes e.g. `<aws/../>`, then system includes, e.g. <string>, and finally our own code e.g. `#include "host_info.h"`
- Changed class' `#define` to match Google's define standard of no prefix and single underline as suffix
- Fixes complaints from Style Check
- Updated HTML Util to use a map rather than multiple string compares

## Testing
- [x] Unit Testing
- [x] Integration w/ Driver Manual Testing. This was a connection test (i.e. calling our auth code) for ADFS, IAM, Secret Manager, and OKTA.
