### PR TITLE
Change to minor version agnostic `python3` command inside the static analysis GitHub action

### DIFF
--- a/.github/workflows/run_static_analysis.yml
+++ b/.github/workflows/run_static_analysis.yml
@@ -28,9 +28,9 @@ jobs:
       - name: Install dependencies
         run: |
           brew install cppcheck llvm unixodbc
-          python3.9 -m venv ./venv
+          python3 -m venv ./venv
           source ./venv/bin/activate
-          python3.9 -m pip install codechecker
+          python3 -m pip install codechecker
 
       - name: Cache AWS SDK libraries
         id: cache-dynamic-aws-sdk


### PR DESCRIPTION
# Summary
Current Python command inside static analysis YML uses a specific minor version which is no longer included in the `macos-14` runner.

## Testing
Commit the change and let the static analysis job run.