### PR TITLE
fix: parse region & logging

### DIFF
--- a/src/authentication/authentication_provider.cc
+++ b/src/authentication/authentication_provider.cc
@@ -255,16 +255,14 @@ bool GenerateConnectAuthToken(char* token, unsigned int max_size, const char* db
 }
 
 bool GetCredentialsFromSecretsManager(const char* secret_id, const char* region, Credentials* credentials) {
+    LoggerWrapper::initialize();
     if (1 == ++sdk_ref_count) {
         std::lock_guard<std::mutex> lock(sdk_mutex);
         Aws::InitAPI(sdk_opts);
     }
 
     std::string region_str = region;
-
-    if (region_str.empty() && !SecretsManagerHelper::TryParseRegionFromSecretId(secret_id, region_str)) {
-        region_str = Aws::Region::US_EAST_1;
-    }
+    SecretsManagerHelper::ParseRegionFromSecretId(secret_id, region_str);
 
     // configure the secrets manager client according to the region determined
     Aws::SecretsManager::SecretsManagerClientConfiguration sm_client_cfg;

--- a/src/authentication/secrets_manager_helper.h
+++ b/src/authentication/secrets_manager_helper.h
@@ -38,8 +38,8 @@ class SecretsManagerHelper {
             : sm_client(std::move(sm_client)) {}
         ~SecretsManagerHelper() = default;
 
-        // attempts to match secret_ID to a secrets ARN regex and parses the region portion; returns true if parsed, false if not
-        static bool TryParseRegionFromSecretId(const Aws::String& secret_id, Aws::String& region);
+        // Tries to parse region from secret id or from user input, else default to us-east-1
+        static void ParseRegionFromSecretId(const Aws::String& secret_id, Aws::String& region);
 
         // fetches credentials from the configured secrets manager client and stored the retrieved values into username and password
         bool FetchCredentials(const Aws::String& secret_id);

--- a/test/unit_test/authentication/secrets_manager_helper_test.cc
+++ b/test/unit_test/authentication/secrets_manager_helper_test.cc
@@ -104,11 +104,34 @@ TEST_F(SecretsManagerHelperTest, FetchCredentialsError) {
   EXPECT_FALSE(res);
 }
 
-TEST_F(SecretsManagerHelperTest, TryParseRegionFromSecretIdOK) {
-  Aws::String secretIdWithRegion = "arn:aws:secretsmanager:us-east-2:otherthings";
+TEST_F(SecretsManagerHelperTest, ParseRegionFromSecretId_FullArn_NoRegion) {
+  Aws::String secretIdWithRegion = "arn:aws:secretsmanager:us-east-2:secretId";
   Aws::String region = "";
 
-  bool res = SecretsManagerHelper::TryParseRegionFromSecretId(secretIdWithRegion, region);
-  EXPECT_TRUE(res);
+  SecretsManagerHelper::ParseRegionFromSecretId(secretIdWithRegion, region);
   EXPECT_EQ(region, "us-east-2");
+}
+
+TEST_F(SecretsManagerHelperTest, ParseRegionFromSecretId_FullArn_RegionInput) {
+  Aws::String secretIdWithRegion = "arn:aws:secretsmanager:us-east-2:secretId";
+  Aws::String region = "us-west-1";
+
+  SecretsManagerHelper::ParseRegionFromSecretId(secretIdWithRegion, region);
+  EXPECT_EQ(region, "us-east-2");
+}
+
+TEST_F(SecretsManagerHelperTest, ParseRegionFromSecretId_IdOnly_RegionInput) {
+  Aws::String secretIdWithRegion = "secretId";
+  Aws::String region = "us-west-1";
+
+  SecretsManagerHelper::ParseRegionFromSecretId(secretIdWithRegion, region);
+  EXPECT_EQ(region, "us-west-1");
+}
+
+TEST_F(SecretsManagerHelperTest, ParseRegionFromSecretId_IdOnly_Default) {
+  Aws::String secretIdWithRegion = "secretId";
+  Aws::String region = "";
+
+  SecretsManagerHelper::ParseRegionFromSecretId(secretIdWithRegion, region);
+  EXPECT_EQ(region, "us-east-1");
 }


### PR DESCRIPTION
# Summary
Fixes SM using wrong region

## Description
- Adds additional logging & initialization if only SM is called
- Moved logic of defaulting to helper
- Always parse the input secrets. Given a full ARN, the region there will always be correct as apposed to the user's input or the driver's default (us-east-1 for PG).

## Testing
- Updates unit tests for region parsing to cover the cases of defaulting, using full secret arn, and replacements.
