### PR TITLE
Replace `convert_wchar_to_char` with `sqlwchar_to_string` that is verified to work with `SQLWCHAR` strings return from `SQLGetDiagRec`

### DIFF
--- a/src/util/logger_wrapper.h
+++ b/src/util/logger_wrapper.h
@@ -39,6 +39,12 @@
 #include <filesystem>
 #include <glog/logging.h>
 
+#ifdef WIN32
+    #include <windows.h>
+#endif
+
+#include <sqltypes.h>
+
 namespace logger_config {
     const std::string PROGRAM_NAME = "aws-rds-odbc";
     const std::string LOG_LOCATION = std::filesystem::temp_directory_path().append("aws-rds-odbc").string();
@@ -50,6 +56,7 @@ public:
     static void initialize();
 
     static std::string convert_wchar_to_char (const wchar_t* wstr);
+    static std::string sqlwchar_to_string(const SQLWCHAR* sqlwchar);
 
     // Prevent copy constructors
     LoggerWrapper(const LoggerWrapper&) = delete;

--- a/src/util/odbc_helper.cc
+++ b/src/util/odbc_helper.cc
@@ -140,11 +140,11 @@ void OdbcHelper::LogMessage(const std::string& log_message, SQLHANDLE handle, in
             LOG(ERROR) << "Invalid handle";
         } else if (SQL_SUCCEEDED(ret)) {
 #ifdef UNICODE
-            std::string narrow_sqlstate = LoggerWrapper::convert_wchar_to_char(sqlstate);
-            std::string narrow_message = LoggerWrapper::convert_wchar_to_char(message);
-            LOG(ERROR) << narrow_sqlstate << narrow_message;
+            std::string narrow_sqlstate = LoggerWrapper::sqlwchar_to_string(sqlstate);
+            std::string narrow_message = LoggerWrapper::sqlwchar_to_string(message);
+            LOG(ERROR) << narrow_sqlstate << ": " << narrow_message;
 #else
-            LOG(ERROR) << sqlstate << message;
+            LOG(ERROR) << sqlstate << ": " << message;
 #endif            
         }
             

--- a/test/unit_test/util/logger_wrapper_test.cc
+++ b/test/unit_test/util/logger_wrapper_test.cc
@@ -40,11 +40,13 @@ protected:
     void TearDown() override {}
 };
 
-TEST_F(LoggerWrapperHelperTest, convert_wchar_to_char_nullptr_returns_empty_string) {
-    EXPECT_EQ("", LoggerWrapper::convert_wchar_to_char(nullptr));
+TEST_F(LoggerWrapperHelperTest, sqlwchar_to_string_nullptr_returns_empty_string) {
+    EXPECT_EQ("", LoggerWrapper::sqlwchar_to_string(nullptr));
 }
 
-TEST_F(LoggerWrapperHelperTest, convert_wchar_to_char_wchar_converted) {
-    EXPECT_EQ("Wide character string", LoggerWrapper::convert_wchar_to_char(L"Wide character string"));
+#ifdef WIN32
+TEST_F(LoggerWrapperHelperTest, sqlwchar_to_string_converted) {
+    EXPECT_EQ("Wide character string", LoggerWrapper::sqlwchar_to_string(L"Wide character string"));
 }
+#endif
 


### PR DESCRIPTION
# Summary

See https://github.com/orgs/aws/projects/237/views/3?pane=issue&itemId=92390744.

## Description

`sqlwchar_to_string` uses a platform independent method that via manual testing, is verified to work with `SQLWCHAR` strings returned from `SQLGetDiagRec` which is used by `OdbcHelper::LogMessage` to log ODBC API error messages.

## Testing
- Unit tests
- Manual testing on macOS and Windows
