### PR TITLE
Disable limitless in connection string

### DIFF
--- a/src/limitless/limitless_router_monitor.h
+++ b/src/limitless/limitless_router_monitor.h
@@ -63,6 +63,12 @@ public:
 
     virtual bool IsStopped();
 protected:
+#ifdef UNICODE
+    std::wstring connection_string;
+#else
+    std::string connection_string;
+#endif
+    
     std::atomic_bool stopped = false;
 
     unsigned int interval_ms;
@@ -75,5 +81,11 @@ protected:
 
     void run(SQLHENV henv, SQLHDBC conn, SQLTCHAR *connection_string, SQLSMALLINT connection_string_len, int host_port);
 };
+
+#ifdef UNICODE
+#define LIMITLESS_ENABLED_KEY   L"LIMITLESSENABLED"
+#else
+#define LIMITLESS_ENABLED_KEY   "LIMITLESSENABLED"
+#endif
 
 #endif // LIMITLESSROUTERMONITOR_H_


### PR DESCRIPTION
# Summary

Make sure that calls to SQLDriverConnect(W) don't spin up their own limitless monitors by disabling the limitless enabled option in the connection string.

## Description

Uses regex to find and replace "LIMITLESSENABLED=1" with "LIMITLESSENABLED=0" in the input connection string to the limitless router monitor.

Also stores the connection string in a std::wstring/std::string member variable so that the library doesn't depend on the string existing for the lifecycle of the monitor.

## Testing

- [x] Unit tests pass
