### PR TITLE
chore: enable logging on MacOS and allow stderr threshold configuration

### DIFF
--- a/src/util/logger_wrapper.cc
+++ b/src/util/logger_wrapper.cc
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 #ifdef WIN32
     #include <windows.h>
 #else
@@ -21,13 +20,15 @@
 
 #include "logger_wrapper.h"
 
-void LoggerWrapper::initialize() { initialize(logger_config::LOG_LOCATION); }
+void LoggerWrapper::initialize() {
+    initialize(logger_config::LOG_LOCATION, 4);
+}
 
-void LoggerWrapper::initialize(std::string log_location) {
-#ifndef XCODE_BUILD
+void LoggerWrapper::initialize(std::string log_location, int threshold) {
+    threshold = threshold >= 0 ? threshold : 4; // Set to 4 to disable console output.
     static LoggerWrapper instance;
     if (!instance.init) {
-        FLAGS_stderrthreshold = 4; // Disable console output
+        FLAGS_stderrthreshold = threshold;
         FLAGS_timestamp_in_logfile_name = false;
         if (log_location.empty()) {
             log_location = logger_config::LOG_LOCATION;
@@ -36,14 +37,11 @@ void LoggerWrapper::initialize(std::string log_location) {
         google::InitGoogleLogging(logger_config::PROGRAM_NAME.c_str());
         instance.init = true;
     }
-#endif
 }
 
 void LoggerWrapper::set_log_directory(const std::string& directory_path) {
-#ifndef XCODE_BUILD
     if (!std::filesystem::exists(directory_path)) {
         std::filesystem::create_directory(directory_path);
     }
     FLAGS_log_dir = directory_path;
-#endif
 }

--- a/src/util/logger_wrapper.h
+++ b/src/util/logger_wrapper.h
@@ -32,14 +32,14 @@
 
 namespace logger_config {
     const std::string PROGRAM_NAME = "aws-rds-odbc";
-    const std::string LOG_LOCATION = std::filesystem::temp_directory_path().append("aws-rds-odbc").string();
+    const std::string LOG_LOCATION = std::filesystem::temp_directory_path().append(PROGRAM_NAME).string();
 }  // namespace logger_config
 
 // Initializes glog once
 class LoggerWrapper {
 public:
     static void initialize();
-    static void initialize(std::string log_location);
+    static void initialize(std::string log_location, int threshold);
 
     // Prevent copy constructors
     LoggerWrapper(const LoggerWrapper&) = delete;

--- a/src/util/rds_logger_service.cc
+++ b/src/util/rds_logger_service.cc
@@ -15,6 +15,6 @@
 #include "rds_logger_service.h"
 #include "logger_wrapper.h"
 
-void initialize_rds_logger(const char* log_dir) {
-    LoggerWrapper::initialize(log_dir);
+void initialize_rds_logger(const char* log_dir, int threshold) {
+    LoggerWrapper::initialize(log_dir, threshold);
 }

--- a/src/util/rds_logger_service.h
+++ b/src/util/rds_logger_service.h
@@ -23,7 +23,7 @@ extern "C" {
  *
  * @param log_dir Directory to contain the AWS RDS ODBC library logs.
  */
-void initialize_rds_logger(const char* log_dir);
+void initialize_rds_logger(const char* log_dir, int threshold);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
# Summary

Output logs when using the driver on MacOS.
Add a threshold configuration parameter so we can enable logging to console output during testing.

## Description
<!--- Description of the ticket. e.g., What is the ticket accomplishing, why is it important, what areas of the code does it affect, etc. -->

## Testing
<!--- Steps taken to test this change. e.g. Adding unit tests, integration tests, and/or manual testing -->
