### PR TITLE
chore: rename methods so library has use consistent naming style

### DIFF
--- a/src/authentication/adfs/adfs.cc
+++ b/src/authentication/adfs/adfs.cc
@@ -51,7 +51,7 @@ std::string AdfsCredentialsProvider::GetSAMLAssertion(std::string& err_info) {
     std::smatch matches;
     std::string action;
     if (std::regex_search(body, matches, std::regex(FORM_ACTION_PATTERN))) {
-        action = HtmlUtil::escape_html_entity(matches.str(1));
+        action = HtmlUtil::EscapeHtmlEntity(matches.str(1));
     } else {
         err_info = "Could not extract action from the response body";
         return retval;
@@ -131,7 +131,7 @@ std::string AdfsCredentialsProvider::get_value_by_key(const std::string& input, 
 
     std::smatch matches;
     if (std::regex_search(input, matches, std::regex(pattern))) {
-        return HtmlUtil::escape_html_entity(matches.str(2));
+        return HtmlUtil::EscapeHtmlEntity(matches.str(2));
     }
     return "";
 }

--- a/src/authentication/html_util.cc
+++ b/src/authentication/html_util.cc
@@ -26,7 +26,7 @@ const std::unordered_map<std::string, char> HtmlUtil::HTML_DECODE_MAP = {
     {"&quot;", '"'}
 };
 
-std::string HtmlUtil::escape_html_entity(const std::string& html) {
+std::string HtmlUtil::EscapeHtmlEntity(const std::string& html) {
     std::string retval;
     DLOG(INFO) << "Before HTML escape modification: " << html;
     int i = 0;

--- a/src/authentication/html_util.h
+++ b/src/authentication/html_util.h
@@ -20,7 +20,7 @@
 
 class HtmlUtil {
 public:
-    static std::string escape_html_entity(const std::string& html);
+    static std::string EscapeHtmlEntity(const std::string& html);
 private:
     static const std::unordered_map<std::string, char> HTML_DECODE_MAP;
 };

--- a/src/authentication/okta/okta.cc
+++ b/src/authentication/okta/okta.cc
@@ -54,7 +54,7 @@ std::string OktaCredentialsProvider::GetSAMLAssertion(std::string& err_info) {
 
     std::smatch matches;
     if (std::regex_search(body, matches, std::regex(SAML_RESPONSE_PATTERN))) {
-        return HtmlUtil::escape_html_entity(matches.str(1));
+        return HtmlUtil::EscapeHtmlEntity(matches.str(1));
     }
     LOG(WARNING) << "No SAML response found in response";
     return "";

--- a/src/failover/cluster_topology_info.cc
+++ b/src/failover/cluster_topology_info.cc
@@ -57,21 +57,21 @@ ClusterTopologyInfo::~ClusterTopologyInfo() {
     readers.clear();
 }
 
-void ClusterTopologyInfo::add_host(const std::shared_ptr<HostInfo>& host_info) {
-    host_info->is_host_writer() ? writers.push_back(host_info) : readers.push_back(host_info);
+void ClusterTopologyInfo::AddHost(const std::shared_ptr<HostInfo>& host_info) {
+    host_info->IsHostWriter() ? writers.push_back(host_info) : readers.push_back(host_info);
     update_time();
-    DLOG(INFO) << (host_info->is_host_writer() ? "Writer" : "Reader" ) << ", " << host_info->get_host_port_pair() << " added to cluster topology.";
+    DLOG(INFO) << (host_info->IsHostWriter() ? "Writer" : "Reader" ) << ", " << host_info->GetHostPortPair() << " added to cluster topology.";
 }
 
-size_t ClusterTopologyInfo::total_hosts() {
+size_t ClusterTopologyInfo::TotalHosts() {
     return writers.size() + readers.size();
 }
 
-size_t ClusterTopologyInfo::num_readers() {
+size_t ClusterTopologyInfo::NumReaders() {
     return readers.size();
 }
 
-std::time_t ClusterTopologyInfo::time_last_updated() const {
+std::time_t ClusterTopologyInfo::TimeLastUpdated() const {
     return last_updated;
 }
 
@@ -80,7 +80,7 @@ void ClusterTopologyInfo::update_time() {
     last_updated = time(nullptr);
 }
 
-std::shared_ptr<HostInfo> ClusterTopologyInfo::get_writer() {
+std::shared_ptr<HostInfo> ClusterTopologyInfo::GetWriter() {
     if (writers.empty()) {
         LOG(ERROR) << "No writer available in cluster topology.";
         throw std::runtime_error("No writer available");
@@ -89,7 +89,7 @@ std::shared_ptr<HostInfo> ClusterTopologyInfo::get_writer() {
     return writers[0];
 }
 
-std::shared_ptr<HostInfo> ClusterTopologyInfo::get_next_reader() {
+std::shared_ptr<HostInfo> ClusterTopologyInfo::GetNextReader() {
     size_t num_readers = readers.size();
     if (readers.empty()) {
         LOG(ERROR) << "No reader available in cluster topology.";
@@ -110,7 +110,7 @@ std::shared_ptr<HostInfo> ClusterTopologyInfo::get_next_reader() {
     return readers[current_reader];
 }
 
-std::shared_ptr<HostInfo> ClusterTopologyInfo::get_reader(int i) {
+std::shared_ptr<HostInfo> ClusterTopologyInfo::GetReader(int i) {
     if (i < 0 || i >= readers.size()) {
         throw std::runtime_error("No reader available at index " + std::to_string(i));
     }
@@ -118,11 +118,11 @@ std::shared_ptr<HostInfo> ClusterTopologyInfo::get_reader(int i) {
     return readers[i];
 }
 
-std::vector<std::shared_ptr<HostInfo>> ClusterTopologyInfo::get_readers() {
+std::vector<std::shared_ptr<HostInfo>> ClusterTopologyInfo::GetReaders() {
     return readers;
 }
 
-std::vector<std::shared_ptr<HostInfo>> ClusterTopologyInfo::get_writers() {
+std::vector<std::shared_ptr<HostInfo>> ClusterTopologyInfo::GetWriters() {
     return writers;
 }
 
@@ -135,13 +135,13 @@ void ClusterTopologyInfo::set_last_used_reader(const std::shared_ptr<HostInfo>& 
 }
 
 void ClusterTopologyInfo::mark_host_down(const std::shared_ptr<HostInfo>& host) {
-    host->set_host_state(DOWN);
-    down_hosts.insert(host->get_host_port_pair());
+    host->SetHostState(DOWN);
+    down_hosts.insert(host->GetHostPortPair());
 }
 
 void ClusterTopologyInfo::mark_host_up(const std::shared_ptr<HostInfo>& host) {
-    host->set_host_state(UP);
-    down_hosts.erase(host->get_host_port_pair());
+    host->SetHostState(UP);
+    down_hosts.erase(host->GetHostPortPair());
 }
 
 std::set<std::string> ClusterTopologyInfo::get_down_hosts() {

--- a/src/failover/cluster_topology_info.h
+++ b/src/failover/cluster_topology_info.h
@@ -32,24 +32,24 @@ public:
     ClusterTopologyInfo(const ClusterTopologyInfo& src_info); //copy constructor
     virtual ~ClusterTopologyInfo();
 
-    void add_host(const std::shared_ptr<HostInfo>& host_info);
-    size_t total_hosts();
-    size_t num_readers(); // return number of readers in the cluster
-    std::time_t time_last_updated() const;
+    void AddHost(const std::shared_ptr<HostInfo>& host_info);
+    size_t TotalHosts();
+    size_t NumReaders(); // return number of readers in the cluster
+    std::time_t TimeLastUpdated() const;
 
-    std::shared_ptr<HostInfo> get_writer();
-    std::shared_ptr<HostInfo> get_next_reader();
-    // TODO(yuenhcol) - Ponder if the get_reader below is needed. In general user of this should not need to deal with indexes.
+    std::shared_ptr<HostInfo> GetWriter();
+    std::shared_ptr<HostInfo> GetNextReader();
+    // TODO(yuenhcol) - Ponder if the GetReader below is needed. In general user of this should not need to deal with indexes.
     // One case that comes to mind, if we were to try to do a random shuffle of readers or hosts in general like JDBC driver
-    // we could do random shuffle of host indices and call the get_reader for specific index in order we wanted.
-    std::shared_ptr<HostInfo> get_reader(int i);
-    std::vector<std::shared_ptr<HostInfo>> get_writers();
-    std::vector<std::shared_ptr<HostInfo>> get_readers();
+    // we could do random shuffle of host indices and call the GetReader for specific index in order we wanted.
+    std::shared_ptr<HostInfo> GetReader(int i);
+    std::vector<std::shared_ptr<HostInfo>> GetWriters();
+    std::vector<std::shared_ptr<HostInfo>> GetReaders();
 
 private:
     int current_reader = -1;
     std::time_t last_updated;
-    std::set<std::string> down_hosts; // maybe not needed, HostInfo has is_host_down() method
+    std::set<std::string> down_hosts; // maybe not needed, HostInfo has IsHostDown() method
     //std::vector<HostInfo*> hosts;
     std::shared_ptr<HostInfo> last_used_reader;  // TODO(yuenhcol) perhaps this overlaps with current_reader and is not needed
 

--- a/src/failover/cluster_topology_monitor.h
+++ b/src/failover/cluster_topology_monitor.h
@@ -61,22 +61,22 @@ public:
         uint64_t high_refresh_rate_ns, uint64_t refresh_rate_ns);
     ~ClusterTopologyMonitor();
 
-    void set_cluster_id(const std::string& cluster_id);
-    std::vector<HostInfo> force_refresh(bool verify_writer, uint64_t timeout_ms);
-    std::vector<HostInfo> force_refresh(SQLHDBC hdbc, uint64_t timeout_ms);
+    void SetClusterId(const std::string& cluster_id);
+    std::vector<HostInfo> ForceRefresh(bool verify_writer, uint64_t timeout_ms);
+    std::vector<HostInfo> ForceRefresh(SQLHDBC hdbc, uint64_t timeout_ms);
 
-    void start_monitor();
+    void StartMonitor();
 
 protected:
     void run();
-    std::vector<HostInfo> wait_for_topology_update(uint64_t timeout_ms);
-    void delay_main_thread(bool use_high_refresh_rate);
-    std::vector<HostInfo> fetch_topology_update_cache(SQLHDBC hdbc);
-    void update_topology_cache(const std::vector<HostInfo>& hosts);
+    std::vector<HostInfo> WaitForTopologyUpdate(uint64_t timeout_ms);
+    void DelayMainThread(bool use_high_refresh_rate);
+    std::vector<HostInfo> FetchTopologyUpdateCache(SQLHDBC hdbc);
+    void UpdateTopologyCache(const std::vector<HostInfo>& hosts);
     #ifdef UNICODE
-    std::wstring conn_for_host(const std::string& new_host);
+    std::wstring ConnForHost(const std::string& new_host);
     #else
-    std::string conn_for_host(const std::string& new_host);
+    std::string ConnForHost(const std::string& new_host);
     #endif
 
 private:

--- a/src/failover/cluster_topology_query_helper.cc
+++ b/src/failover/cluster_topology_query_helper.cc
@@ -24,10 +24,10 @@ ClusterTopologyQueryHelper::ClusterTopologyQueryHelper(
     const std::string& node_id_query):
     port{port} {
     #ifdef UNICODE
-    endpoint_template_ = StringHelper::to_wstring(endpoint_template);
-    topology_query_ = StringHelper::to_wstring(topology_query);
-    writer_id_query_ = StringHelper::to_wstring(writer_id_query);
-    node_id_query_ = StringHelper::to_wstring(node_id_query);
+    endpoint_template_ = StringHelper::ToWstring(endpoint_template);
+    topology_query_ = StringHelper::ToWstring(topology_query);
+    writer_id_query_ = StringHelper::ToWstring(writer_id_query);
+    node_id_query_ = StringHelper::ToWstring(node_id_query);
     #else
         endpoint_template_ = endpoint_template;
         topology_query_ = topology_query;
@@ -36,7 +36,7 @@ ClusterTopologyQueryHelper::ClusterTopologyQueryHelper(
     #endif
     }
 
-std::string ClusterTopologyQueryHelper::get_writer_id(SQLHDBC hdbc) {
+std::string ClusterTopologyQueryHelper::GetWriterId(SQLHDBC hdbc) {
     SQLRETURN rc;
     SQLHSTMT stmt = SQL_NULL_HANDLE;
     SQLTCHAR writer_id[BUFFER_SIZE];
@@ -61,7 +61,7 @@ std::string ClusterTopologyQueryHelper::get_writer_id(SQLHDBC hdbc) {
     return std::string(AS_CHAR(writer_id));
 }
 
-std::string ClusterTopologyQueryHelper::get_node_id(SQLHDBC hdbc) {
+std::string ClusterTopologyQueryHelper::GetNodeId(SQLHDBC hdbc) {
     SQLRETURN rc;
     SQLHSTMT stmt = SQL_NULL_HANDLE;
     SQLTCHAR writer_id[BUFFER_SIZE];
@@ -86,7 +86,7 @@ std::string ClusterTopologyQueryHelper::get_node_id(SQLHDBC hdbc) {
     return std::string(AS_CHAR(writer_id));
 }
 
-std::vector<HostInfo> ClusterTopologyQueryHelper::query_topology(SQLHDBC hdbc) {
+std::vector<HostInfo> ClusterTopologyQueryHelper::QueryTopology(SQLHDBC hdbc) {
     SQLHSTMT stmt = SQL_NULL_HANDLE;
     SQLTCHAR node_id[BUFFER_SIZE];
     bool is_writer;
@@ -122,23 +122,23 @@ std::vector<HostInfo> ClusterTopologyQueryHelper::query_topology(SQLHDBC hdbc) {
     bool fetch_success = OdbcHelper::FetchResults(stmt, "ClusterTopologyQueryHelper failed to fetch topology from results");
     std::vector<HostInfo> hosts;
     while (fetch_success) {
-        hosts.push_back(create_host(node_id, is_writer, cpu_usage, replica_lag_ms, last_update_timestamp));
+        hosts.push_back(CreateHost(node_id, is_writer, cpu_usage, replica_lag_ms, last_update_timestamp));
         fetch_success = OdbcHelper::FetchResults(stmt, "ClusterTopologyQueryHelper failed to fetch topology from results");
     }
     return hosts;
 }
 
-HostInfo ClusterTopologyQueryHelper::create_host(SQLTCHAR* node_id, bool is_writer, SQLREAL cpu_usage, SQLREAL replica_lag_ms, SQL_TIMESTAMP_STRUCT update_timestamp) {
+HostInfo ClusterTopologyQueryHelper::CreateHost(SQLTCHAR* node_id, bool is_writer, SQLREAL cpu_usage, SQLREAL replica_lag_ms, SQL_TIMESTAMP_STRUCT update_timestamp) {
     uint64_t weight = (std::round(replica_lag_ms) * SCALE_TO_PERCENT) + std::round(cpu_usage);
-    std::string endpoint_url = get_endpoint(node_id);
+    std::string endpoint_url = GetEndpoint(node_id);
     HostInfo hi = HostInfo(endpoint_url, port, UP, is_writer, nullptr, weight, update_timestamp);
     return hi;
 }
 
-std::string ClusterTopologyQueryHelper::get_endpoint(SQLTCHAR* node_id) {
+std::string ClusterTopologyQueryHelper::GetEndpoint(SQLTCHAR* node_id) {
 #ifdef UNICODE
-    std::string res = StringHelper::to_string(endpoint_template_);
-    std::string node_id_str = StringHelper::to_string(AS_WCHAR(node_id));
+    std::string res = StringHelper::ToString(endpoint_template_);
+    std::string node_id_str = StringHelper::ToString(AS_WCHAR(node_id));
 #else
     std::string res(endpoint_template_);
     std::string node_id_str = AS_CHAR(node_id);

--- a/src/failover/cluster_topology_query_helper.h
+++ b/src/failover/cluster_topology_query_helper.h
@@ -31,11 +31,11 @@
 class ClusterTopologyQueryHelper {    
 public:
     ClusterTopologyQueryHelper(int port, const std::string& endpoint_template, const std::string& topology_query, const std::string& writer_id_query, const std::string& node_id_query);
-    virtual std::string get_writer_id(SQLHDBC hdbc);
-    virtual std::string get_node_id(SQLHDBC hdbc);
-    virtual std::vector<HostInfo> query_topology(SQLHDBC hdbc);
-    virtual HostInfo create_host(SQLTCHAR* node_id, bool is_writer, SQLREAL cpu_usage, SQLREAL replica_lag_ms, SQL_TIMESTAMP_STRUCT update_timestamp);
-    virtual std::string get_endpoint(SQLTCHAR* node_id);
+    virtual std::string GetWriterId(SQLHDBC hdbc);
+    virtual std::string GetNodeId(SQLHDBC hdbc);
+    virtual std::vector<HostInfo> QueryTopology(SQLHDBC hdbc);
+    virtual HostInfo CreateHost(SQLTCHAR* node_id, bool is_writer, SQLREAL cpu_usage, SQLREAL replica_lag_ms, SQL_TIMESTAMP_STRUCT update_timestamp);
+    virtual std::string GetEndpoint(SQLTCHAR* node_id);
 
 private:
     const int port;

--- a/src/host_availability/host_availability_strategy.h
+++ b/src/host_availability/host_availability_strategy.h
@@ -24,8 +24,8 @@ class HostAvailabilityStrategy {
 public:
     virtual ~HostAvailabilityStrategy() = default;
 
-    virtual void set_host_availability(HostAvailability hostAvailability) = 0;
-    virtual HostAvailability get_host_availability(HostAvailability rawHostAvailability) = 0;
+    virtual void SetHostAvailability(HostAvailability hostAvailability) = 0;
+    virtual HostAvailability GetHostAvailability(HostAvailability rawHostAvailability) = 0;
 };
 
 #endif // HOSTAVAILABILITYSTRATEGY_H_

--- a/src/host_availability/simple_host_availability_strategy.cc
+++ b/src/host_availability/simple_host_availability_strategy.cc
@@ -14,10 +14,10 @@
 
 #include "simple_host_availability_strategy.h"
 
-void SimpleHostAvailabilityStrategy::set_host_availability(HostAvailability HostAvailability) {
+void SimpleHostAvailabilityStrategy::SetHostAvailability(HostAvailability HostAvailability) {
     // Do nothing
 }
 
-HostAvailability SimpleHostAvailabilityStrategy::get_host_availability(HostAvailability rawHostAvailability) {
+HostAvailability SimpleHostAvailabilityStrategy::GetHostAvailability(HostAvailability rawHostAvailability) {
     return rawHostAvailability;
 }

--- a/src/host_availability/simple_host_availability_strategy.h
+++ b/src/host_availability/simple_host_availability_strategy.h
@@ -19,8 +19,8 @@
 
 class SimpleHostAvailabilityStrategy: public HostAvailabilityStrategy {
 public:    
-    void set_host_availability(HostAvailability hostAvailability) override;
-    HostAvailability get_host_availability(HostAvailability rawHostAvailability) override;
+    void SetHostAvailability(HostAvailability hostAvailability) override;
+    HostAvailability GetHostAvailability(HostAvailability rawHostAvailability) override;
 };
 
 #endif // SIMPLEHOSTAVAILABILITYSTRATEGY_H_

--- a/src/host_info.cc
+++ b/src/host_info.cc
@@ -30,7 +30,7 @@ HostInfo::HostInfo(std::string host, int port, HOST_STATE state, bool is_writer,
  *
  * @return the host
  */
-std::string HostInfo::get_host() const {
+std::string HostInfo::GetHost() const {
     return host;
 }
 
@@ -39,7 +39,7 @@ std::string HostInfo::get_host() const {
  *
  * @return the port
  */
-int HostInfo::get_port() const {
+int HostInfo::GetPort() const {
     return port;
 }
 
@@ -48,11 +48,11 @@ int HostInfo::get_port() const {
  *
  * @return the weight
  */
-uint64_t HostInfo::get_weight() const {
+uint64_t HostInfo::GetWeight() const {
     return weight;
 }
 
-SQL_TIMESTAMP_STRUCT HostInfo::get_last_updated_time() const {
+SQL_TIMESTAMP_STRUCT HostInfo::GetLastUpdatedTime() const {
     return last_updated_timestamp;
 }
 
@@ -61,42 +61,42 @@ SQL_TIMESTAMP_STRUCT HostInfo::get_last_updated_time() const {
  *
  * @return the host:port representation of this host
  */
-std::string HostInfo::get_host_port_pair() const {
-    return get_host() + host_port_separator + std::to_string(get_port());
+std::string HostInfo::GetHostPortPair() const {
+    return GetHost() + host_port_separator + std::to_string(GetPort());
 }
 
-bool HostInfo::equal_host_port_pair(const HostInfo& hi) const {
-    return get_host_port_pair() == hi.get_host_port_pair();
+bool HostInfo::EqualHostPortPair(const HostInfo& hi) const {
+    return GetHostPortPair() == hi.GetHostPortPair();
 }
 
-HOST_STATE HostInfo::get_host_state() const {
+HOST_STATE HostInfo::GetHostState() const {
     return host_state;
 }
 
-void HostInfo::set_host_state(HOST_STATE state) {
+void HostInfo::SetHostState(HOST_STATE state) {
     host_state = state;
 }
 
-bool HostInfo::is_host_up() const {
+bool HostInfo::IsHostUp() const {
     return host_state == UP;
 }
 
-bool HostInfo::is_host_down() const {
+bool HostInfo::IsHostDown() const {
     return host_state == DOWN;
 }
 
-bool HostInfo::is_host_writer() const {
+bool HostInfo::IsHostWriter() const {
     return is_writer;
 }
 
-void HostInfo::mark_as_writer(bool writer) {
+void HostInfo::MarkAsWriter(bool writer) {
     is_writer = writer;
 }
 
-std::shared_ptr<HostAvailabilityStrategy> HostInfo::get_host_availability_strategy() const {
+std::shared_ptr<HostAvailabilityStrategy> HostInfo::GetHostAvailabilityStrategy() const {
     return host_availability_strategy;
 }
 
-void HostInfo::set_host_availability_strategy(std::shared_ptr<HostAvailabilityStrategy> new_host_availability_strategy) {
+void HostInfo::SetHostAvailabilityStrategy(std::shared_ptr<HostAvailabilityStrategy> new_host_availability_strategy) {
     host_availability_strategy = std::move(new_host_availability_strategy);
 }

--- a/src/host_info.h
+++ b/src/host_info.h
@@ -42,24 +42,24 @@ public:
 
     ~HostInfo() = default;
 
-    bool equal_host_port_pair(const HostInfo& hi) const;
-    bool is_host_down() const;
-    bool is_host_up() const;
-    bool is_host_writer() const;
+    bool EqualHostPortPair(const HostInfo& hi) const;
+    bool IsHostDown() const;
+    bool IsHostUp() const;
+    bool IsHostWriter() const;
 
-    void mark_as_writer(bool writer);
+    void MarkAsWriter(bool writer);
 
-    std::string get_host() const;
-    int get_port() const;
-    std::string get_host_port_pair() const;
-    uint64_t get_weight() const;
-    SQL_TIMESTAMP_STRUCT get_last_updated_time() const;
+    std::string GetHost() const;
+    int GetPort() const;
+    std::string GetHostPortPair() const;
+    uint64_t GetWeight() const;
+    SQL_TIMESTAMP_STRUCT GetLastUpdatedTime() const;
 
-    void set_host_state(HOST_STATE state);
-    HOST_STATE get_host_state() const;
+    void SetHostState(HOST_STATE state);
+    HOST_STATE GetHostState() const;
 
-    void set_host_availability_strategy(std::shared_ptr<HostAvailabilityStrategy> new_host_availability_strategy);
-    std::shared_ptr<HostAvailabilityStrategy> get_host_availability_strategy() const;
+    void SetHostAvailabilityStrategy(std::shared_ptr<HostAvailabilityStrategy> new_host_availability_strategy);
+    std::shared_ptr<HostAvailabilityStrategy> GetHostAvailabilityStrategy() const;
 
     std::string session_id;
     std::string replica_lag;

--- a/src/host_selector/highest_weight_host_selector.cc
+++ b/src/host_selector/highest_weight_host_selector.cc
@@ -14,12 +14,12 @@
 
 #include "highest_weight_host_selector.h"
 
-HostInfo HighestWeightHostSelector::get_host(std::vector<HostInfo> hosts, bool is_writer, std::unordered_map<std::string, std::string>) {
+HostInfo HighestWeightHostSelector::GetHost(std::vector<HostInfo> hosts, bool is_writer, std::unordered_map<std::string, std::string>) {
     std::vector<HostInfo> eligible_hosts;
     eligible_hosts.reserve(hosts.size());
 
     std::copy_if(hosts.begin(), hosts.end(), std::back_inserter(eligible_hosts), [&is_writer](const HostInfo& host) {
-        return host.is_host_up() && is_writer == host.is_host_writer();
+        return host.IsHostUp() && is_writer == host.IsHostWriter();
     });
 
     if (eligible_hosts.empty()) {
@@ -30,7 +30,7 @@ HostInfo HighestWeightHostSelector::get_host(std::vector<HostInfo> hosts, bool i
         eligible_hosts.begin(),
         eligible_hosts.end(),
         [](const HostInfo& a, const HostInfo& b) {
-            return a.get_weight() < b.get_weight();
+            return a.GetWeight() < b.GetWeight();
         }
     );
 

--- a/src/host_selector/highest_weight_host_selector.h
+++ b/src/host_selector/highest_weight_host_selector.h
@@ -20,7 +20,7 @@
 
 class HighestWeightHostSelector: public HostSelector {
 public:
-    HostInfo get_host(std::vector<HostInfo> hosts, bool is_writer,
+    HostInfo GetHost(std::vector<HostInfo> hosts, bool is_writer,
         std::unordered_map<std::string, std::string> properties) override;
 };
 

--- a/src/host_selector/host_selector.h
+++ b/src/host_selector/host_selector.h
@@ -24,7 +24,7 @@
 class HostSelector {
 public:
     virtual ~HostSelector() = default;
-    virtual HostInfo get_host(std::vector<HostInfo> hosts, bool is_writer,
+    virtual HostInfo GetHost(std::vector<HostInfo> hosts, bool is_writer,
         std::unordered_map<std::string, std::string> properties) = 0;
 };
 

--- a/src/host_selector/random_host_selector.cc
+++ b/src/host_selector/random_host_selector.cc
@@ -16,14 +16,14 @@
 
 #include <random>
 
-HostInfo RandomHostSelector::get_host(std::vector<HostInfo> hosts, bool is_writer,
+HostInfo RandomHostSelector::GetHost(std::vector<HostInfo> hosts, bool is_writer,
     std::unordered_map<std::string, std::string>) {
 
     std::vector<HostInfo> selection;
     selection.reserve(hosts.size());
 
     std::copy_if(hosts.begin(), hosts.end(), std::back_inserter(selection), [&is_writer](const HostInfo& host) {
-        return host.is_host_up() && (is_writer ? host.is_host_writer() : true);
+        return host.IsHostUp() && (is_writer ? host.IsHostWriter() : true);
     });
 
     if (selection.empty()) {

--- a/src/host_selector/random_host_selector.h
+++ b/src/host_selector/random_host_selector.h
@@ -20,7 +20,7 @@
 
 class RandomHostSelector: public HostSelector {
 public:
-    HostInfo get_host(std::vector<HostInfo> hosts, bool is_writer,
+    HostInfo GetHost(std::vector<HostInfo> hosts, bool is_writer,
         std::unordered_map<std::string, std::string> properties) override;
 };
 

--- a/src/host_selector/round_robin_host_selector.h
+++ b/src/host_selector/round_robin_host_selector.h
@@ -25,11 +25,11 @@
 
 class RoundRobinHostSelector: public HostSelector {
 public:
-    HostInfo get_host(std::vector<HostInfo> hosts, bool is_writer,
+    HostInfo GetHost(std::vector<HostInfo> hosts, bool is_writer,
         std::unordered_map<std::string, std::string> properties) override;
-    static void set_round_robin_weight(std::vector<HostInfo> hosts, 
+    static void SetRoundRobinWeight(std::vector<HostInfo> hosts, 
         std::unordered_map<std::string, std::string>& properties);
-    static void clear_cache();
+    static void ClearCache();
 
 private:
     const int DEFAULT_WEIGHT = 1;

--- a/src/limitless/limitless_monitor_service.cc
+++ b/src/limitless/limitless_monitor_service.cc
@@ -159,8 +159,8 @@ std::shared_ptr<HostInfo> LimitlessMonitorService::GetHostInfo(const std::string
     }
 
     std::unordered_map<std::string, std::string> properties;
-    RoundRobinHostSelector::set_round_robin_weight(hosts, properties);
-    std::shared_ptr<HostInfo> host = std::make_shared<HostInfo>(round_robin.get_host(hosts, true, properties));
+    RoundRobinHostSelector::SetRoundRobinWeight(hosts, properties);
+    std::shared_ptr<HostInfo> host = std::make_shared<HostInfo>(round_robin.GetHost(hosts, true, properties));
     return host;
 }
 
@@ -185,7 +185,7 @@ bool GetLimitlessInstance(const SQLTCHAR *connection_string_c_str, int host_port
         return false;
     }
 
-    strncpy(db_instance->server, host->get_host().c_str(), db_instance->server_size);
+    strncpy(db_instance->server, host->GetHost().c_str(), db_instance->server_size);
     return true;
 }
 

--- a/src/limitless/limitless_query_helper.cc
+++ b/src/limitless/limitless_query_helper.cc
@@ -103,7 +103,7 @@ std::vector<HostInfo> LimitlessQueryHelper::QueryForLimitlessRouters(SQLHDBC con
     std::vector<HostInfo> limitless_routers;
 
     while (SQL_SUCCEEDED(rc = SQLFetch(hstmt))) {
-        limitless_routers.push_back(CreateHost(load_value, router_endpoint_value, host_port_to_map));
+        limitless_routers.push_back(create_host(load_value, router_endpoint_value, host_port_to_map));
     }
 
     SQLFreeHandle(SQL_HANDLE_STMT, hstmt);
@@ -111,7 +111,7 @@ std::vector<HostInfo> LimitlessQueryHelper::QueryForLimitlessRouters(SQLHDBC con
     return limitless_routers;
 }
 
-HostInfo LimitlessQueryHelper::CreateHost(const SQLCHAR* load, const SQLCHAR* router_endpoint, const int host_port_to_map) {
+HostInfo LimitlessQueryHelper::create_host(const SQLCHAR* load, const SQLCHAR* router_endpoint, const int host_port_to_map) {
     int64_t weight = std::round(WEIGHT_SCALING - (atof(reinterpret_cast<const char *>(load)) * WEIGHT_SCALING));
 
     if (weight < MIN_WEIGHT || weight > MAX_WEIGHT) {

--- a/src/limitless/limitless_query_helper.h
+++ b/src/limitless/limitless_query_helper.h
@@ -40,7 +40,7 @@ public:
     static std::vector<HostInfo> QueryForLimitlessRouters(SQLHDBC conn, int host_port_to_map);
 
 private:
-    static HostInfo CreateHost(const SQLCHAR* load, const SQLCHAR* router_endpoint, int host_port_to_map);
+    static HostInfo create_host(const SQLCHAR* load, const SQLCHAR* router_endpoint, int host_port_to_map);
 };
 
 #endif // LIMITLESSQUERYHELPER_H_

--- a/src/limitless/limitless_router_monitor.cc
+++ b/src/limitless/limitless_router_monitor.cc
@@ -96,7 +96,7 @@ void LimitlessRouterMonitor::Open(
     }
 
     // start monitoring thread; if block_and_query_immediately is false, then conn is SQL_NULL_HANDLE, and the thread will connect after the monitor interval has passed
-    this->monitor_thread = std::make_shared<std::thread>(&LimitlessRouterMonitor::run, this, henv, conn, reinterpret_cast<SQLTCHAR *>(this->connection_string.data()), connection_string_len, host_port);
+    this->monitor_thread = std::make_shared<std::thread>(&LimitlessRouterMonitor::Run, this, henv, conn, reinterpret_cast<SQLTCHAR *>(this->connection_string.data()), connection_string_len, host_port);
 }
 
 bool LimitlessRouterMonitor::IsStopped() {
@@ -116,7 +116,7 @@ void LimitlessRouterMonitor::Close() {
     }
 }
 
-void LimitlessRouterMonitor::run(SQLHENV henv, SQLHDBC conn, SQLTCHAR *connection_string, SQLSMALLINT connection_string_len, int host_port) {
+void LimitlessRouterMonitor::Run(SQLHENV henv, SQLHDBC conn, SQLTCHAR *connection_string, SQLSMALLINT connection_string_len, int host_port) {
     SQLSMALLINT out_connection_string_len; // unused
 
     while (!this->stopped) {

--- a/src/limitless/limitless_router_monitor.h
+++ b/src/limitless/limitless_router_monitor.h
@@ -64,7 +64,7 @@ protected:
 
     std::shared_ptr<std::thread> monitor_thread = nullptr;
 
-    void run(SQLHENV henv, SQLHDBC conn, SQLTCHAR *connection_string, SQLSMALLINT connection_string_len, int host_port);
+    void Run(SQLHENV henv, SQLHDBC conn, SQLTCHAR *connection_string, SQLSMALLINT connection_string_len, int host_port);
 };
 
 #ifdef UNICODE

--- a/src/util/logger_wrapper.cc
+++ b/src/util/logger_wrapper.cc
@@ -20,11 +20,11 @@
 
 #include "logger_wrapper.h"
 
-void LoggerWrapper::initialize() {
-    initialize(logger_config::LOG_LOCATION, 4);
+void LoggerWrapper::Initialize() {
+    Initialize(logger_config::LOG_LOCATION, 4);
 }
 
-void LoggerWrapper::initialize(std::string log_location, int threshold) {
+void LoggerWrapper::Initialize(std::string log_location, int threshold) {
     threshold = threshold >= 0 ? threshold : 4; // Set to 4 to disable console output.
     static LoggerWrapper instance;
     if (!instance.init) {

--- a/src/util/logger_wrapper.h
+++ b/src/util/logger_wrapper.h
@@ -38,8 +38,8 @@ namespace logger_config {
 // Initializes glog once
 class LoggerWrapper {
 public:
-    static void initialize();
-    static void initialize(std::string log_location, int threshold);
+    static void Initialize();
+    static void Initialize(std::string log_location, int threshold);
 
     // Prevent copy constructors
     LoggerWrapper(const LoggerWrapper&) = delete;

--- a/src/util/odbc_helper.cc
+++ b/src/util/odbc_helper.cc
@@ -127,7 +127,7 @@ void OdbcHelper::LogMessage(const std::string& log_message, SQLHANDLE handle, in
             LOG(ERROR) << "Invalid handle";
         } else if (SQL_SUCCEEDED(ret)) {
             #ifdef UNICODE
-            LOG(ERROR) << StringHelper::to_string(sqlstate) << ": " << StringHelper::to_string(message);
+            LOG(ERROR) << StringHelper::ToString(sqlstate) << ": " << StringHelper::ToString(message);
             #else
             LOG(ERROR) << sqlstate << ": " << message;
             #endif            

--- a/src/util/rds_logger_service.cc
+++ b/src/util/rds_logger_service.cc
@@ -15,6 +15,6 @@
 #include "rds_logger_service.h"
 #include "logger_wrapper.h"
 
-void initialize_rds_logger(const char* log_dir, int threshold) {
-    LoggerWrapper::initialize(log_dir, threshold);
+void InitializeRdsLogger(const char* log_dir, int threshold) {
+    LoggerWrapper::Initialize(log_dir, threshold);
 }

--- a/src/util/rds_logger_service.h
+++ b/src/util/rds_logger_service.h
@@ -23,7 +23,7 @@ extern "C" {
  *
  * @param log_dir Directory to contain the AWS RDS ODBC library logs.
  */
-void initialize_rds_logger(const char* log_dir, int threshold);
+void InitializeRdsLogger(const char* log_dir, int threshold);
 
 #ifdef __cplusplus
 }

--- a/src/util/rds_utils.cc
+++ b/src/util/rds_utils.cc
@@ -48,35 +48,35 @@ namespace {
     const std::regex IPV6_COMPRESSED_PATTERN(R"#(^(([0-9A-Fa-f]{1,4}(:[0-9A-Fa-f]{1,4}){0,5})?)::(([0-9A-Fa-f]{1,4}(:[0-9A-Fa-f]{1,4}){0,5})?)$)#");
 }
 
-bool RdsUtils::is_dns_pattern_valid(const std::string& host) {
+bool RdsUtils::IsDnsPatternValid(const std::string& host) {
     return ( host.find('?') != std::string::npos);
 }
 
-bool RdsUtils::is_rds_dns(const std::string& host) {
+bool RdsUtils::IsRdsDns(const std::string& host) {
     return std::regex_match(host, AURORA_DNS_PATTERN) || std::regex_match(host, AURORA_CHINA_DNS_PATTERN);
 }
 
-bool RdsUtils::is_rds_cluster_dns(const std::string& host) {
+bool RdsUtils::IsRdsClusterDns(const std::string& host) {
     return std::regex_match(host, AURORA_CLUSTER_PATTERN) || std::regex_match(host, AURORA_CHINA_CLUSTER_PATTERN);
 }
 
-bool RdsUtils::is_rds_proxy_dns(const std::string& host) {
+bool RdsUtils::IsRdsProxyDns(const std::string& host) {
     return std::regex_match(host, AURORA_PROXY_DNS_PATTERN) || std::regex_match(host, AURORA_CHINA_PROXY_DNS_PATTERN);
 }
 
-bool RdsUtils::is_rds_writer_cluster_dns(const std::string& host) {
+bool RdsUtils::IsRdsWriterClusterDns(const std::string& host) {
     return std::regex_match(host, AURORA_WRITER_CLUSTER_PATTERN) || std::regex_match(host, AURORA_CHINA_WRITER_CLUSTER_PATTERN);
 }
 
-bool RdsUtils::is_rds_reader_cluster_dns(const std::string& host) {
+bool RdsUtils::IsRdsReaderClusterDns(const std::string& host) {
     return std::regex_match(host, AURORA_READER_CLUSTER_PATTERN) || std::regex_match(host, AURORA_CHINA_READER_CLUSTER_PATTERN);
 }
 
-bool RdsUtils::is_rds_custom_cluster_dns(const std::string& host) {
+bool RdsUtils::IsRdsCustomClusterDns(const std::string& host) {
     return std::regex_match(host, AURORA_CUSTOM_CLUSTER_PATTERN) || std::regex_match(host, AURORA_CHINA_CUSTOM_CLUSTER_PATTERN);
 }
 
-std::string RdsUtils::get_rds_cluster_host_url(const std::string& host) {
+std::string RdsUtils::GetRdsClusterHostUrl(const std::string& host) {
     auto f = [ host ](const std::regex& pattern) {
         std::smatch m;
         if (std::regex_search(host, m, pattern) && m.size() > 1) {
@@ -104,7 +104,7 @@ std::string RdsUtils::get_rds_cluster_host_url(const std::string& host) {
     return f(AURORA_CHINA_CLUSTER_PATTERN);
 }
 
-std::string RdsUtils::get_rds_cluster_id(const std::string& host) {
+std::string RdsUtils::GetRdsClusterId(const std::string& host) {
     auto f = [ host ](const std::regex& pattern) {
         std::smatch m;
         if (std::regex_search(host, m, pattern) && m.size() > 1 && !m.str(2).empty()) {
@@ -121,7 +121,7 @@ std::string RdsUtils::get_rds_cluster_id(const std::string& host) {
     return f(AURORA_CHINA_DNS_PATTERN);
 }
 
-std::string RdsUtils::get_rds_instance_id(const std::string& host) {
+std::string RdsUtils::GetRdsInstanceId(const std::string& host) {
     auto f = [ host ](const std::regex& pattern) {
         std::smatch m;
         if (std::regex_search(host, m, pattern) && m.size() > 1 && m.str(2).empty()) {
@@ -138,7 +138,7 @@ std::string RdsUtils::get_rds_instance_id(const std::string& host) {
     return f(AURORA_CHINA_DNS_PATTERN);
 }
 
-std::string RdsUtils::get_rds_instance_host_pattern(const std::string& host) {
+std::string RdsUtils::GetRdsInstanceHostPattern(const std::string& host) {
     auto f = [ host ](const std::regex& pattern) {
         std::smatch m;
         if (std::regex_search(host, m, pattern) && m.size() > 4 && !m.str(3).empty()) {
@@ -158,7 +158,7 @@ std::string RdsUtils::get_rds_instance_host_pattern(const std::string& host) {
     return f(AURORA_CHINA_DNS_PATTERN);
 }
 
-std::string RdsUtils::get_rds_region(const std::string& host) {
+std::string RdsUtils::GetRdsRegion(const std::string& host) {
     auto f = [ host ](const std::regex& pattern) {
         std::smatch m;
         if (std::regex_search(host, m, pattern) && m.size() > 4 && !m.str(4).empty()) {
@@ -175,10 +175,10 @@ std::string RdsUtils::get_rds_region(const std::string& host) {
     return f(AURORA_CHINA_DNS_PATTERN);
 }
 
-bool RdsUtils::is_ipv4(const std::string& host) {
+bool RdsUtils::IsIpv4(const std::string& host) {
     return std::regex_match(host, IPV4_PATTERN);
 }
 
-bool RdsUtils::is_ipv6(const std::string& host) {
+bool RdsUtils::IsIpv6(const std::string& host) {
     return std::regex_match(host, IPV6_PATTERN) || std::regex_match(host, IPV6_COMPRESSED_PATTERN);
 }

--- a/src/util/rds_utils.h
+++ b/src/util/rds_utils.h
@@ -19,21 +19,21 @@
 
 class RdsUtils {
    public:
-    static bool is_dns_pattern_valid(const std::string& host);
-    static bool is_rds_dns(const std::string& host);
-    static bool is_rds_cluster_dns(const std::string& host);
-    static bool is_rds_proxy_dns(const std::string& host);
-    static bool is_rds_writer_cluster_dns(const std::string& host);
-    static bool is_rds_reader_cluster_dns(const std::string& host);
-    static bool is_rds_custom_cluster_dns(const std::string& host);
-    static bool is_ipv4(const std::string& host);
-    static bool is_ipv6(const std::string& host);
+    static bool IsDnsPatternValid(const std::string& host);
+    static bool IsRdsDns(const std::string& host);
+    static bool IsRdsClusterDns(const std::string& host);
+    static bool IsRdsProxyDns(const std::string& host);
+    static bool IsRdsWriterClusterDns(const std::string& host);
+    static bool IsRdsReaderClusterDns(const std::string& host);
+    static bool IsRdsCustomClusterDns(const std::string& host);
+    static bool IsIpv4(const std::string& host);
+    static bool IsIpv6(const std::string& host);
 
-    static std::string get_rds_cluster_host_url(const std::string& host);
-    static std::string get_rds_cluster_id(const std::string& host);
-    static std::string get_rds_instance_host_pattern(const std::string& host);
-    static std::string get_rds_instance_id(const std::string& host);
-    static std::string get_rds_region(const std::string& host);
+    static std::string GetRdsClusterHostUrl(const std::string& host);
+    static std::string GetRdsClusterId(const std::string& host);
+    static std::string GetRdsInstanceHostPattern(const std::string& host);
+    static std::string GetRdsInstanceId(const std::string& host);
+    static std::string GetRdsRegion(const std::string& host);
 };
 
 #endif

--- a/src/util/sliding_cache_map.cc
+++ b/src/util/sliding_cache_map.cc
@@ -17,12 +17,12 @@
 #include "host_selector/round_robin_property.h"
 
 template <typename K, typename V>
-void SlidingCacheMap<K, V>::put(const K& key, const V& value) {
-    put(key, value, DEFAULT_EXPIRATION_SEC);
+void SlidingCacheMap<K, V>::Put(const K& key, const V& value) {
+    Put(key, value, DEFAULT_EXPIRATION_SEC);
 }
 
 template <typename K, typename V>
-void SlidingCacheMap<K, V>::put(const K& key, const V& value, int sec_ttl) {
+void SlidingCacheMap<K, V>::Put(const K& key, const V& value, int sec_ttl) {
     std::lock_guard<std::mutex> lock(cache_lock);
     std::chrono::steady_clock::time_point expiry_time =
         std::chrono::steady_clock::now() + std::chrono::seconds(sec_ttl);
@@ -30,7 +30,7 @@ void SlidingCacheMap<K, V>::put(const K& key, const V& value, int sec_ttl) {
 }
 
 template <typename K, typename V>
-V SlidingCacheMap<K, V>::get(const K& key) {
+V SlidingCacheMap<K, V>::Get(const K& key) {
     std::lock_guard<std::mutex> lock(cache_lock);
     std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
     if (auto itr = cache.find(key); itr != cache.end()) {
@@ -47,7 +47,7 @@ V SlidingCacheMap<K, V>::get(const K& key) {
 }
 
 template <typename K, typename V>
-bool SlidingCacheMap<K, V>::find(const K& key) {
+bool SlidingCacheMap<K, V>::Find(const K& key) {
     std::lock_guard<std::mutex> lock(cache_lock);
     std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
     if (auto itr = cache.find(key); itr != cache.end()) {
@@ -64,7 +64,7 @@ bool SlidingCacheMap<K, V>::find(const K& key) {
 }
 
 template <typename K, typename V>
-unsigned int SlidingCacheMap<K, V>::size() {
+unsigned int SlidingCacheMap<K, V>::Size() {
     std::lock_guard<std::mutex> lock(cache_lock);
     std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
     for (auto itr = cache.begin(); itr != cache.end();) {
@@ -78,7 +78,7 @@ unsigned int SlidingCacheMap<K, V>::size() {
 }
 
 template <typename K, typename V>
-void SlidingCacheMap<K, V>::clear() {
+void SlidingCacheMap<K, V>::Clear() {
     std::lock_guard<std::mutex> lock(cache_lock);
     cache.clear();
 }

--- a/src/util/sliding_cache_map.h
+++ b/src/util/sliding_cache_map.h
@@ -26,12 +26,12 @@ class SlidingCacheMap {
 public:
     SlidingCacheMap() = default;
 
-    void put(const K& key, const V& value);
-    void put(const K& key, const V& value, int sec_ttl);
-    V get(const K& key);
-    bool find(const K& key);
-    unsigned int size();
-    void clear();
+    void Put(const K& key, const V& value);
+    void Put(const K& key, const V& value, int sec_ttl);
+    V Get(const K& key);
+    bool Find(const K& key);
+    unsigned int Size();
+    void Clear();
 
 private:
     struct CacheEntry {

--- a/src/util/string_helper.h
+++ b/src/util/string_helper.h
@@ -39,13 +39,13 @@ typedef std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
 
 class StringHelper {
    public:
-    static std::wstring to_wstring(const std::string& src) {
+    static std::wstring ToWstring(const std::string& src) {
         if (src.empty()) {
             return std::wstring();
         }
         return converter{}.from_bytes(src);
     }
-    static std::string to_string(const std::wstring& src) {
+    static std::string ToString(const std::wstring& src) {
         if (src.empty()) {
             return std::string();
         }

--- a/test/unit_test/failover/cluster_topology_info_test.cc
+++ b/test/unit_test/failover/cluster_topology_info_test.cc
@@ -38,7 +38,7 @@ class ClusterTopologyInfoTest : public testing::Test {
     void TearDown() override {}
 };
 
-TEST_F(ClusterTopologyInfoTest, getNextWriter) {
+TEST_F(ClusterTopologyInfoTest, get_next_writer) {
   std::shared_ptr<HostInfo> writer_host_info =
     std::make_shared<HostInfo>(base_host_string, base_port, HOST_STATE::UP, true, simple_host_availability_strategy);
   std::shared_ptr<HostInfo> reader_host_info_a =
@@ -46,14 +46,14 @@ TEST_F(ClusterTopologyInfoTest, getNextWriter) {
   std::shared_ptr<HostInfo> reader_host_info_b =
     std::make_shared<HostInfo>(base_host_string, base_port, HOST_STATE::UP, false, simple_host_availability_strategy);
   std::shared_ptr<ClusterTopologyInfo> cluster_topology_info = std::make_shared<ClusterTopologyInfo>();
-  cluster_topology_info->add_host(writer_host_info);
-  cluster_topology_info->add_host(reader_host_info_a);
-  cluster_topology_info->add_host(reader_host_info_b);
-  std::shared_ptr<HostInfo> host_info = cluster_topology_info->get_writer();
+  cluster_topology_info->AddHost(writer_host_info);
+  cluster_topology_info->AddHost(reader_host_info_a);
+  cluster_topology_info->AddHost(reader_host_info_b);
+  std::shared_ptr<HostInfo> host_info = cluster_topology_info->GetWriter();
   EXPECT_EQ(writer_host_info, host_info);
 }
 
-TEST_F(ClusterTopologyInfoTest, getNextWriter_empty) {
+TEST_F(ClusterTopologyInfoTest, get_next_writer_empty) {
   std::shared_ptr<ClusterTopologyInfo> cluster_topology_info = std::make_shared<ClusterTopologyInfo>();
-  EXPECT_THROW(cluster_topology_info->get_writer(), std::runtime_error);
+  EXPECT_THROW(cluster_topology_info->GetWriter(), std::runtime_error);
 }

--- a/test/unit_test/failover/cluster_topology_monitor_test.cc
+++ b/test/unit_test/failover/cluster_topology_monitor_test.cc
@@ -72,9 +72,9 @@ TEST_F(ClusterTopologyMonitorTest, run_panic_no_cached_topology_writer_conn) {
         .WillRepeatedly(Return(true));
     EXPECT_CALL(*mock_odbc_helper, CheckResult(testing::_, testing::_, testing::_, testing::_))
         .WillRepeatedly(Return(true));
-    // First connection (open_any_conn_get_hosts) is the writer
+    // First connection (open_any_conn_GetHosts) is the writer
     // Note, this query should only return a string if the connected one is the writer
-    EXPECT_CALL(*mock_query_helper, get_writer_id(testing::_))
+    EXPECT_CALL(*mock_query_helper, GetWriterId(testing::_))
         .WillOnce(Return("writer"))
         .WillRepeatedly(Return(""));
 
@@ -83,7 +83,7 @@ TEST_F(ClusterTopologyMonitorTest, run_panic_no_cached_topology_writer_conn) {
     topology.push_back(HostInfo("reader_a.server.com", 1234, UP, false, nullptr));
     topology.push_back(HostInfo("reader_b.server.com", 1234, UP, false, nullptr));
 
-    EXPECT_CALL(*mock_query_helper, query_topology(testing::_))
+    EXPECT_CALL(*mock_query_helper, QueryTopology(testing::_))
         .WillRepeatedly(Return(topology));
 
     // Create monitor, starts main thread
@@ -97,13 +97,13 @@ TEST_F(ClusterTopologyMonitorTest, run_panic_no_cached_topology_writer_conn) {
     high_refresh_rate_ns,
     refresh_rate_ns
     );
-    monitor->start_monitor();
+    monitor->StartMonitor();
 
     // Sleep to give time for topology to update
     std::this_thread::sleep_for(std::chrono::seconds(sleep_duration_sec));
 
-    // Check if topology is updated by main thread / open_any_conn_get_hosts
-    EXPECT_EQ(1, topology_map->size());
+    // Check if topology is updated by main thread / open_any_conn_GetHosts
+    EXPECT_EQ(1, topology_map->Size());
 }
 
 // Should do the same as above, except internally will not mark conn as writer
@@ -115,10 +115,10 @@ TEST_F(ClusterTopologyMonitorTest, run_panic_no_cached_topology_init_reader_conn
         .WillRepeatedly(Return(true));
     EXPECT_CALL(*mock_odbc_helper, CheckResult(testing::_, testing::_, testing::_, testing::_))
         .WillRepeatedly(Return(true));
-    // First connection (open_any_conn_get_hosts) is a reader
+    // First connection (open_any_conn_GetHosts) is a reader
     // Empty string represents that query did not return result, meaning the connection is not the writer
-    EXPECT_CALL(*mock_query_helper, get_writer_id(testing::_))
-        .WillOnce(Return("")) // First connection by main thread, open_any_conn_get_hosts
+    EXPECT_CALL(*mock_query_helper, GetWriterId(testing::_))
+        .WillOnce(Return("")) // First connection by main thread, open_any_conn_GetHosts
         .WillOnce(Return("writer")) // Node thread connects to writer
         .WillRepeatedly(Return(""));;
 
@@ -127,7 +127,7 @@ TEST_F(ClusterTopologyMonitorTest, run_panic_no_cached_topology_init_reader_conn
     topology.push_back(HostInfo("reader_a.server.com", 1234, UP, false, nullptr));
     topology.push_back(HostInfo("reader_b.server.com", 1234, UP, false, nullptr));
 
-    EXPECT_CALL(*mock_query_helper, query_topology(testing::_))
+    EXPECT_CALL(*mock_query_helper, QueryTopology(testing::_))
         .WillRepeatedly(Return(topology));
 
     // Create monitor, starts main thread
@@ -141,13 +141,13 @@ TEST_F(ClusterTopologyMonitorTest, run_panic_no_cached_topology_init_reader_conn
     high_refresh_rate_ns,
     refresh_rate_ns
     );
-    monitor->start_monitor();
+    monitor->StartMonitor();
 
     // Sleep to give time for topology to update
     std::this_thread::sleep_for(std::chrono::seconds(sleep_duration_sec));
 
-    // Check if topology is updated by main thread / open_any_conn_get_hosts
-    EXPECT_EQ(1, topology_map->size());
+    // Check if topology is updated by main thread / open_any_conn_GetHosts
+    EXPECT_EQ(1, topology_map->Size());
 }
 
 TEST_F(ClusterTopologyMonitorTest, run_panic_with_cached_hosts) {
@@ -155,7 +155,7 @@ TEST_F(ClusterTopologyMonitorTest, run_panic_with_cached_hosts) {
     topology.push_back(HostInfo("writer.server.com", 1234, UP, true, nullptr));
     topology.push_back(HostInfo("reader_a.server.com", 1234, UP, false, nullptr));
     topology.push_back(HostInfo("reader_b.server.com", 1234, UP, false, nullptr));
-    topology_map->put(cluster_id, topology);
+    topology_map->Put(cluster_id, topology);
 
     EXPECT_CALL(*mock_odbc_helper, Cleanup(testing::_, testing::_, testing::_))
         .Times(testing::AtLeast(0));
@@ -163,9 +163,9 @@ TEST_F(ClusterTopologyMonitorTest, run_panic_with_cached_hosts) {
         .WillRepeatedly(Return(true));
     EXPECT_CALL(*mock_odbc_helper, CheckResult(testing::_, testing::_, testing::_, testing::_))
         .WillRepeatedly(Return(true));
-    EXPECT_CALL(*mock_query_helper, query_topology(testing::_))
+    EXPECT_CALL(*mock_query_helper, QueryTopology(testing::_))
         .WillRepeatedly(Return(topology));
-    EXPECT_CALL(*mock_query_helper, get_writer_id(testing::_))
+    EXPECT_CALL(*mock_query_helper, GetWriterId(testing::_))
         .WillOnce(Return("writer"))
         .WillRepeatedly(Return(""));
 
@@ -180,11 +180,11 @@ TEST_F(ClusterTopologyMonitorTest, run_panic_with_cached_hosts) {
         high_refresh_rate_ns,
         refresh_rate_ns
     );
-    monitor->start_monitor();
+    monitor->StartMonitor();
 
     // Sleep to give time for topology to update
     std::this_thread::sleep_for(std::chrono::seconds(sleep_duration_sec));
 
     // Check that topology did not increase in size or decrease
-    EXPECT_EQ(1, topology_map->size());
+    EXPECT_EQ(1, topology_map->Size());
 }

--- a/test/unit_test/failover/cluster_topology_query_helper_test.cc
+++ b/test/unit_test/failover/cluster_topology_query_helper_test.cc
@@ -34,7 +34,7 @@ protected:
     void TearDown() override {}
 };
 
-TEST_F(ClusterTopologyQueryHelperTest, create_host) {
+TEST_F(ClusterTopologyQueryHelperTest, CreateHost) {
     SQLTCHAR* node_id = AS_SQLTCHAR(TEXT("node_id"));
     int port = 1;
     bool is_writer = false;
@@ -46,7 +46,7 @@ TEST_F(ClusterTopologyQueryHelperTest, create_host) {
     std::shared_ptr<ClusterTopologyQueryHelper> query_helper =
         std::make_shared<ClusterTopologyQueryHelper>(port, "?", "", "", "");
 
-    HostInfo host = query_helper->create_host(node_id, false, cpu_usage, replica_lag, timestamp);
+    HostInfo host = query_helper->CreateHost(node_id, false, cpu_usage, replica_lag, timestamp);
     std::string expected;
 #ifdef UNICODE
     std::wstring node_id_wstr(node_id);
@@ -54,13 +54,13 @@ TEST_F(ClusterTopologyQueryHelperTest, create_host) {
 #else
     expected = std::string(AS_CHAR(node_id));
 #endif
-    EXPECT_EQ(expected, host.get_host());
-    EXPECT_EQ(port, host.get_port());
-    EXPECT_EQ(weight, host.get_weight());
-    EXPECT_EQ(is_writer, host.is_host_writer());
+    EXPECT_EQ(expected, host.GetHost());
+    EXPECT_EQ(port, host.GetPort());
+    EXPECT_EQ(weight, host.GetWeight());
+    EXPECT_EQ(is_writer, host.IsHostWriter());
 }
 
-TEST_F(ClusterTopologyQueryHelperTest, get_endpoint) {
+TEST_F(ClusterTopologyQueryHelperTest, GetEndpoint) {
     std::shared_ptr<ClusterTopologyQueryHelper> query_helper =
         std::make_shared<ClusterTopologyQueryHelper>(1234, "?", "", "", "");
     SQLTCHAR* node_id = AS_SQLTCHAR(TEXT("node-id"));
@@ -71,10 +71,10 @@ TEST_F(ClusterTopologyQueryHelperTest, get_endpoint) {
 #else
     expected = std::string(AS_CHAR(node_id));
 #endif
-    EXPECT_EQ(expected, query_helper->get_endpoint(node_id));
+    EXPECT_EQ(expected, query_helper->GetEndpoint(node_id));
 }
 
-TEST_F(ClusterTopologyQueryHelperTest, get_endpoint_extra_values) {
+TEST_F(ClusterTopologyQueryHelperTest, GetEndpoint_extra_values) {
     std::string endpoint_template = "?.other-values";
     std::shared_ptr<ClusterTopologyQueryHelper> query_helper =
         std::make_shared<ClusterTopologyQueryHelper>(1234, endpoint_template, "", "", "");
@@ -87,5 +87,5 @@ TEST_F(ClusterTopologyQueryHelperTest, get_endpoint_extra_values) {
 #else
     expected = std::string(endpoint_template).replace(endpoint_template.find("?"), 1, AS_CHAR(node_id));
 #endif
-    EXPECT_EQ(expected, query_helper->get_endpoint(node_id));
+    EXPECT_EQ(expected, query_helper->GetEndpoint(node_id));
 }

--- a/test/unit_test/host_availability/simple_host_availability_strategy_test.cc
+++ b/test/unit_test/host_availability/simple_host_availability_strategy_test.cc
@@ -27,19 +27,19 @@ class SimpleHostAvailabilityStrategyTest : public testing::Test {
     void TearDown() override {}
 };
 
-TEST_F(SimpleHostAvailabilityStrategyTest, set_host_availability) {
+TEST_F(SimpleHostAvailabilityStrategyTest, SetHostAvailability) {
     std::shared_ptr<SimpleHostAvailabilityStrategy> simple_host_availability_strategy = 
         std::make_shared<SimpleHostAvailabilityStrategy>();
 
-    simple_host_availability_strategy->set_host_availability(AVAILABLE);
-    // set_host_availability does nothing so ensure it can be called
+    simple_host_availability_strategy->SetHostAvailability(AVAILABLE);
+    // SetHostAvailability does nothing so ensure it can be called
     // without throwing an exception
     SUCCEED();
 }
 
-TEST_F(SimpleHostAvailabilityStrategyTest, get_host_availability) {
+TEST_F(SimpleHostAvailabilityStrategyTest, GetHostAvailability) {
     std::shared_ptr<SimpleHostAvailabilityStrategy> simple_host_availability_strategy = 
         std::make_shared<SimpleHostAvailabilityStrategy>();
-    EXPECT_EQ(AVAILABLE, simple_host_availability_strategy->get_host_availability(AVAILABLE));
-    EXPECT_EQ(NOT_AVAILABLE, simple_host_availability_strategy->get_host_availability(NOT_AVAILABLE));
+    EXPECT_EQ(AVAILABLE, simple_host_availability_strategy->GetHostAvailability(AVAILABLE));
+    EXPECT_EQ(NOT_AVAILABLE, simple_host_availability_strategy->GetHostAvailability(NOT_AVAILABLE));
 }

--- a/test/unit_test/host_info_test.cc
+++ b/test/unit_test/host_info_test.cc
@@ -40,71 +40,71 @@ class HostInfoTest : public testing::Test {
     std::shared_ptr<HostInfo> hostInfo;
 };
 
-TEST_F(HostInfoTest, get_host) {
-  EXPECT_EQ(host, hostInfo->get_host());
+TEST_F(HostInfoTest, GetHost) {
+  EXPECT_EQ(host, hostInfo->GetHost());
 }
 
-TEST_F(HostInfoTest, get_port) {
-  EXPECT_EQ(port, hostInfo->get_port());
+TEST_F(HostInfoTest, GetPort) {
+  EXPECT_EQ(port, hostInfo->GetPort());
 }
 
-TEST_F(HostInfoTest, get_host_port_pair) {
-  EXPECT_EQ(hostPortPair, hostInfo->get_host_port_pair());
+TEST_F(HostInfoTest, GetHostPortPair) {
+  EXPECT_EQ(hostPortPair, hostInfo->GetHostPortPair());
 }
 
-TEST_F(HostInfoTest, equal_host_port_pair) {
+TEST_F(HostInfoTest, EqualHostPortPair) {
   HostInfo hostInfoHostPortMatches(host, port, UP, false, simple_host_availability_strategy);
-  EXPECT_TRUE(hostInfo->equal_host_port_pair(hostInfoHostPortMatches));
+  EXPECT_TRUE(hostInfo->EqualHostPortPair(hostInfoHostPortMatches));
 
   HostInfo hostInfoHostDoesNotMatch(host + "DoesNotMatch", port, UP, false, simple_host_availability_strategy);
-  EXPECT_FALSE(hostInfo->equal_host_port_pair(hostInfoHostDoesNotMatch));
+  EXPECT_FALSE(hostInfo->EqualHostPortPair(hostInfoHostDoesNotMatch));
 
   HostInfo hostInfoPortDoesNotMatch(host, port + 1, UP, false, simple_host_availability_strategy);
-  EXPECT_FALSE(hostInfo->equal_host_port_pair(hostInfoPortDoesNotMatch));
+  EXPECT_FALSE(hostInfo->EqualHostPortPair(hostInfoPortDoesNotMatch));
 }
 
-TEST_F(HostInfoTest, get_host_state) {
-  EXPECT_EQ(UP, hostInfo->get_host_state());
+TEST_F(HostInfoTest, GetHostState) {
+  EXPECT_EQ(UP, hostInfo->GetHostState());
 }
 
-TEST_F(HostInfoTest, get_weight) {
-  EXPECT_EQ(HostInfo::DEFAULT_WEIGHT, hostInfo->get_weight());
+TEST_F(HostInfoTest, GetWeight) {
+  EXPECT_EQ(HostInfo::DEFAULT_WEIGHT, hostInfo->GetWeight());
 }
 
 TEST_F(HostInfoTest, set_host_state) {
-  EXPECT_EQ(UP, hostInfo->get_host_state());
-  hostInfo->set_host_state(DOWN);
-  EXPECT_EQ(DOWN, hostInfo->get_host_state());
+  EXPECT_EQ(UP, hostInfo->GetHostState());
+  hostInfo->SetHostState(DOWN);
+  EXPECT_EQ(DOWN, hostInfo->GetHostState());
 }
 
-TEST_F(HostInfoTest, is_host_up) {
-  EXPECT_TRUE(hostInfo->is_host_up());
+TEST_F(HostInfoTest, IsHostUp) {
+  EXPECT_TRUE(hostInfo->IsHostUp());
 }
 
-TEST_F(HostInfoTest, is_host_down) {
-  EXPECT_FALSE(hostInfo->is_host_down());
+TEST_F(HostInfoTest, IsHostDown) {
+  EXPECT_FALSE(hostInfo->IsHostDown());
 }
 
-TEST_F(HostInfoTest, is_host_writer) {
-  EXPECT_FALSE(hostInfo->is_host_writer());
+TEST_F(HostInfoTest, IsHostWriter) {
+  EXPECT_FALSE(hostInfo->IsHostWriter());
 }
 
-TEST_F(HostInfoTest, mark_as_writer) {
-  EXPECT_FALSE(hostInfo->is_host_writer());
-  hostInfo->mark_as_writer(true);
-  EXPECT_TRUE(hostInfo->is_host_writer());
-  hostInfo->mark_as_writer(false);
-  EXPECT_FALSE(hostInfo->is_host_writer());
+TEST_F(HostInfoTest, MarkAsWriter) {
+  EXPECT_FALSE(hostInfo->IsHostWriter());
+  hostInfo->MarkAsWriter(true);
+  EXPECT_TRUE(hostInfo->IsHostWriter());
+  hostInfo->MarkAsWriter(false);
+  EXPECT_FALSE(hostInfo->IsHostWriter());
 }
 
-TEST_F(HostInfoTest, get_host_availability_strategy) {
-  EXPECT_EQ(simple_host_availability_strategy, hostInfo->get_host_availability_strategy());
+TEST_F(HostInfoTest, GetHostAvailabilityStrategy) {
+  EXPECT_EQ(simple_host_availability_strategy, hostInfo->GetHostAvailabilityStrategy());
 }
 
-TEST_F(HostInfoTest, set_host_availability_strategy) {
-  hostInfo->set_host_availability_strategy(nullptr);
-  EXPECT_EQ(nullptr, hostInfo->get_host_availability_strategy());
+TEST_F(HostInfoTest, SetHostAvailabilityStrategy) {
+  hostInfo->SetHostAvailabilityStrategy(nullptr);
+  EXPECT_EQ(nullptr, hostInfo->GetHostAvailabilityStrategy());
 
-  hostInfo->set_host_availability_strategy(simple_host_availability_strategy);
-  EXPECT_EQ(simple_host_availability_strategy, hostInfo->get_host_availability_strategy());
+  hostInfo->SetHostAvailabilityStrategy(simple_host_availability_strategy);
+  EXPECT_EQ(simple_host_availability_strategy, hostInfo->GetHostAvailabilityStrategy());
 }

--- a/test/unit_test/host_selector/highest_weight_host_selector_test.cc
+++ b/test/unit_test/host_selector/highest_weight_host_selector_test.cc
@@ -56,14 +56,14 @@ protected:
 
 TEST_F(HighestWeightHostSelectorTest, get_highest_reader) {
     HighestWeightHostSelector host_selector;
-    HostInfo host_info = host_selector.get_host(all_hosts, false, empty_map);
-    EXPECT_EQ(reader_host_info_b.get_host(), host_info.get_host());
+    HostInfo host_info = host_selector.GetHost(all_hosts, false, empty_map);
+    EXPECT_EQ(reader_host_info_b.GetHost(), host_info.GetHost());
 }
 
 TEST_F(HighestWeightHostSelectorTest, get_highest_writer) {
     HighestWeightHostSelector host_selector;
-    HostInfo host_info = host_selector.get_host(all_hosts, true, empty_map);
-    EXPECT_EQ(writer_host_info_b.get_host(), host_info.get_host());
+    HostInfo host_info = host_selector.GetHost(all_hosts, true, empty_map);
+    EXPECT_EQ(writer_host_info_b.GetHost(), host_info.GetHost());
 }
 
 TEST_F(HighestWeightHostSelectorTest, get_reader_fail_all_writers) {
@@ -74,7 +74,7 @@ TEST_F(HighestWeightHostSelectorTest, get_reader_fail_all_writers) {
         writer_host_info_c,
         writer_host_info_down_a
     };
-    EXPECT_THROW(host_selector.get_host(hosts, false, empty_map), std::runtime_error);
+    EXPECT_THROW(host_selector.GetHost(hosts, false, empty_map), std::runtime_error);
 }
 
 TEST_F(HighestWeightHostSelectorTest, get_writer_fail_all_readers) {
@@ -85,7 +85,7 @@ TEST_F(HighestWeightHostSelectorTest, get_writer_fail_all_readers) {
         reader_host_info_c,
         reader_host_info_down_a
     };
-    EXPECT_THROW(host_selector.get_host(hosts, true, empty_map), std::runtime_error);
+    EXPECT_THROW(host_selector.GetHost(hosts, true, empty_map), std::runtime_error);
 }
 
 TEST_F(HighestWeightHostSelectorTest, get_reader_all_down) {
@@ -94,7 +94,7 @@ TEST_F(HighestWeightHostSelectorTest, get_reader_all_down) {
         reader_host_info_down_a,
         reader_host_info_down_b
     };
-    EXPECT_THROW(host_selector.get_host(hosts, false, empty_map), std::runtime_error);
+    EXPECT_THROW(host_selector.GetHost(hosts, false, empty_map), std::runtime_error);
 }
 
 TEST_F(HighestWeightHostSelectorTest, get_writer_all_down) {
@@ -103,17 +103,17 @@ TEST_F(HighestWeightHostSelectorTest, get_writer_all_down) {
         writer_host_info_down_a,
         writer_host_info_down_b
     };
-    EXPECT_THROW(host_selector.get_host(hosts, true, empty_map), std::runtime_error);
+    EXPECT_THROW(host_selector.GetHost(hosts, true, empty_map), std::runtime_error);
 }
 
 TEST_F(HighestWeightHostSelectorTest, get_reader_no_hosts) {
     HighestWeightHostSelector host_selector;
     std::vector<HostInfo> hosts = {};
-    EXPECT_THROW(host_selector.get_host(hosts, false, empty_map), std::runtime_error);
+    EXPECT_THROW(host_selector.GetHost(hosts, false, empty_map), std::runtime_error);
 }
 
 TEST_F(HighestWeightHostSelectorTest, get_writer_no_hosts) {
     HighestWeightHostSelector host_selector;
     std::vector<HostInfo> hosts = {};
-    EXPECT_THROW(host_selector.get_host(hosts, true, empty_map), std::runtime_error);
+    EXPECT_THROW(host_selector.GetHost(hosts, true, empty_map), std::runtime_error);
 }

--- a/test/unit_test/host_selector/random_host_selector_test.cc
+++ b/test/unit_test/host_selector/random_host_selector_test.cc
@@ -38,44 +38,44 @@ class RandomHostSelectorTest : public testing::Test {
     void TearDown() override {}
 };
 
-TEST_F(RandomHostSelectorTest, get_writer) {
+TEST_F(RandomHostSelectorTest, GetWriter) {
     RandomHostSelector host_selector;
     std::vector<HostInfo> hosts = {writer_host_info_a, reader_host_info_a, reader_host_info_b};
-    HostInfo host_info = host_selector.get_host(hosts, true, empty_map);
-    EXPECT_EQ(writer_host_info_a.get_host(), host_info.get_host());
+    HostInfo host_info = host_selector.GetHost(hosts, true, empty_map);
+    EXPECT_EQ(writer_host_info_a.GetHost(), host_info.GetHost());
 }
 
 TEST_F(RandomHostSelectorTest, get_live_writer) {
     RandomHostSelector host_selector;
     std::vector<HostInfo> hosts = {writer_host_info_a, writer_host_info_down};
-    HostInfo host_info = host_selector.get_host(hosts, true, empty_map);
-    EXPECT_EQ(writer_host_info_a.get_host(), host_info.get_host());
+    HostInfo host_info = host_selector.GetHost(hosts, true, empty_map);
+    EXPECT_EQ(writer_host_info_a.GetHost(), host_info.GetHost());
 }
 
 TEST_F(RandomHostSelectorTest, get_writer_from_many) {
     RandomHostSelector host_selector;
     std::vector<HostInfo> hosts = {writer_host_info_a, writer_host_info_b, writer_host_info_down,
         reader_host_info_a, reader_host_info_b, reader_host_info_down};
-    HostInfo host_info = host_selector.get_host(hosts, true, empty_map);
-    EXPECT_TRUE(host_info.is_host_writer());
-    EXPECT_TRUE(host_info.is_host_up());
+    HostInfo host_info = host_selector.GetHost(hosts, true, empty_map);
+    EXPECT_TRUE(host_info.IsHostWriter());
+    EXPECT_TRUE(host_info.IsHostUp());
 }
 
 TEST_F(RandomHostSelectorTest, get_writer_fail_all_readers) {
     RandomHostSelector host_selector;
     std::vector<HostInfo> hosts = {reader_host_info_a, reader_host_info_b};
-    EXPECT_THROW(host_selector.get_host(hosts, true, empty_map), std::runtime_error);
+    EXPECT_THROW(host_selector.GetHost(hosts, true, empty_map), std::runtime_error);
 }
 
 TEST_F(RandomHostSelectorTest, get_reader_one_down) {
     RandomHostSelector host_selector;
     std::vector<HostInfo> hosts = {reader_host_info_a, reader_host_info_down};
-    HostInfo host_info = host_selector.get_host(hosts, false, empty_map);
-    EXPECT_EQ(reader_host_info_a.get_host(), host_info.get_host());
+    HostInfo host_info = host_selector.GetHost(hosts, false, empty_map);
+    EXPECT_EQ(reader_host_info_a.GetHost(), host_info.GetHost());
 }
 
 TEST_F(RandomHostSelectorTest, no_hosts) {
     RandomHostSelector host_selector;
     std::vector<HostInfo> hosts = {};
-    EXPECT_THROW(host_selector.get_host(hosts, false, empty_map), std::runtime_error);
+    EXPECT_THROW(host_selector.GetHost(hosts, false, empty_map), std::runtime_error);
 }

--- a/test/unit_test/host_selector/round_robin_host_selector_test.cc
+++ b/test/unit_test/host_selector/round_robin_host_selector_test.cc
@@ -34,55 +34,55 @@ class RoundRobinHostSelectorTest : public testing::Test {
     static void TearDownTestSuite() {}
     // Runs per test case
     void SetUp() override {
-        RoundRobinHostSelector::clear_cache();
+        RoundRobinHostSelector::ClearCache();
     }
     void TearDown() override {}
 };
 
-TEST_F(RoundRobinHostSelectorTest, get_writer) {
+TEST_F(RoundRobinHostSelectorTest, GetWriter) {
     RoundRobinHostSelector host_selector;
     std::unordered_map<std::string, std::string> props;
     std::vector<HostInfo> hosts = {writer_host_info_a, reader_host_info_a, reader_host_info_b};
-    HostInfo host_info = host_selector.get_host(hosts, true, props);
-    EXPECT_EQ(writer_host_info_a.get_host(), host_info.get_host());
+    HostInfo host_info = host_selector.GetHost(hosts, true, props);
+    EXPECT_EQ(writer_host_info_a.GetHost(), host_info.GetHost());
 }
 
 TEST_F(RoundRobinHostSelectorTest, get_writer_fail_all_readers) {
     RoundRobinHostSelector host_selector;
     std::unordered_map<std::string, std::string> props;
     std::vector<HostInfo> hosts = {reader_host_info_a, reader_host_info_b};
-    EXPECT_THROW(host_selector.get_host(hosts, true, props), std::runtime_error);
+    EXPECT_THROW(host_selector.GetHost(hosts, true, props), std::runtime_error);
 }
 
 TEST_F(RoundRobinHostSelectorTest, get_reader_one_down) {
     RoundRobinHostSelector host_selector;
     std::unordered_map<std::string, std::string> props;
     std::vector<HostInfo> hosts = {reader_host_info_down, reader_host_info_a};
-    HostInfo host_info = host_selector.get_host(hosts, false, props);
-    EXPECT_EQ(reader_host_info_a.get_host(), host_info.get_host());
+    HostInfo host_info = host_selector.GetHost(hosts, false, props);
+    EXPECT_EQ(reader_host_info_a.GetHost(), host_info.GetHost());
 }
 
 TEST_F(RoundRobinHostSelectorTest, no_hosts) {
     RoundRobinHostSelector host_selector;
     std::unordered_map<std::string, std::string> props;
     std::vector<HostInfo> hosts = {};
-    EXPECT_THROW(host_selector.get_host(hosts, false, props), std::runtime_error);
+    EXPECT_THROW(host_selector.GetHost(hosts, false, props), std::runtime_error);
 }
 
 TEST_F(RoundRobinHostSelectorTest, get_first_reader) {
     RoundRobinHostSelector host_selector;
     std::unordered_map<std::string, std::string> props;
     std::vector<HostInfo> hosts = {reader_host_info_a, reader_host_info_b, reader_host_info_c};
-    HostInfo host_info = host_selector.get_host(hosts, false, props);
-    EXPECT_EQ(reader_host_info_a.get_host(), host_info.get_host());
+    HostInfo host_info = host_selector.GetHost(hosts, false, props);
+    EXPECT_EQ(reader_host_info_a.GetHost(), host_info.GetHost());
 }
 
 TEST_F(RoundRobinHostSelectorTest, get_first_reader_unsorted_input) {
     RoundRobinHostSelector host_selector;
     std::unordered_map<std::string, std::string> props;
     std::vector<HostInfo> hosts = {reader_host_info_c, reader_host_info_a, reader_host_info_b};
-    HostInfo host_info = host_selector.get_host(hosts, false, props);
-    EXPECT_EQ(reader_host_info_a.get_host(), host_info.get_host());
+    HostInfo host_info = host_selector.GetHost(hosts, false, props);
+    EXPECT_EQ(reader_host_info_a.GetHost(), host_info.GetHost());
 }
 
 TEST_F(RoundRobinHostSelectorTest, get_round_robin_readers_default) {
@@ -90,173 +90,173 @@ TEST_F(RoundRobinHostSelectorTest, get_round_robin_readers_default) {
     std::unordered_map<std::string, std::string> props;
     std::vector<HostInfo> hosts = {reader_host_info_a, reader_host_info_b};
 
-    HostInfo host_info = host_selector.get_host(hosts, false, props);
-    EXPECT_EQ(reader_host_info_a.get_host(), host_info.get_host());
+    HostInfo host_info = host_selector.GetHost(hosts, false, props);
+    EXPECT_EQ(reader_host_info_a.GetHost(), host_info.GetHost());
 
-    host_info = host_selector.get_host(hosts, false, props);
-    EXPECT_EQ(reader_host_info_b.get_host(), host_info.get_host());
+    host_info = host_selector.GetHost(hosts, false, props);
+    EXPECT_EQ(reader_host_info_b.GetHost(), host_info.GetHost());
 
-    host_info = host_selector.get_host(hosts, false, props);
-    EXPECT_EQ(reader_host_info_a.get_host(), host_info.get_host());
+    host_info = host_selector.GetHost(hosts, false, props);
+    EXPECT_EQ(reader_host_info_a.GetHost(), host_info.GetHost());
 }
 
 TEST_F(RoundRobinHostSelectorTest, get_round_robin_readers_weighted) {
     RoundRobinHostSelector host_selector;
     std::unordered_map<std::string, std::string> props;
     props[round_robin_property::HOST_WEIGHT_KEY] = std::string(
-        reader_host_info_a.get_host() + ":2"
-         + "," + reader_host_info_b.get_host() + ":1"
+        reader_host_info_a.GetHost() + ":2"
+         + "," + reader_host_info_b.GetHost() + ":1"
     );
     std::vector<HostInfo> hosts = {reader_host_info_a, reader_host_info_b};
 
-    HostInfo host_info = host_selector.get_host(hosts, false, props);
-    EXPECT_EQ(reader_host_info_a.get_host(), host_info.get_host());
-    host_info = host_selector.get_host(hosts, false, props);
-    EXPECT_EQ(reader_host_info_a.get_host(), host_info.get_host());
+    HostInfo host_info = host_selector.GetHost(hosts, false, props);
+    EXPECT_EQ(reader_host_info_a.GetHost(), host_info.GetHost());
+    host_info = host_selector.GetHost(hosts, false, props);
+    EXPECT_EQ(reader_host_info_a.GetHost(), host_info.GetHost());
 
-    host_info = host_selector.get_host(hosts, false, props);
-    EXPECT_EQ(reader_host_info_b.get_host(), host_info.get_host());
+    host_info = host_selector.GetHost(hosts, false, props);
+    EXPECT_EQ(reader_host_info_b.GetHost(), host_info.GetHost());
 
-    host_info = host_selector.get_host(hosts, false, props);
-    EXPECT_EQ(reader_host_info_a.get_host(), host_info.get_host());
+    host_info = host_selector.GetHost(hosts, false, props);
+    EXPECT_EQ(reader_host_info_a.GetHost(), host_info.GetHost());
 }
 
 TEST_F(RoundRobinHostSelectorTest, get_round_robin_readers_weighted_change) {
     RoundRobinHostSelector host_selector;
     std::unordered_map<std::string, std::string> props;
     props[round_robin_property::HOST_WEIGHT_KEY] = std::string(
-        reader_host_info_a.get_host() + ":2"
-         + "," + reader_host_info_b.get_host() + ":1"
+        reader_host_info_a.GetHost() + ":2"
+         + "," + reader_host_info_b.GetHost() + ":1"
     );
     std::vector<HostInfo> hosts = {reader_host_info_a, reader_host_info_b};
 
-    HostInfo host_info = host_selector.get_host(hosts, false, props);
-    EXPECT_EQ(reader_host_info_a.get_host(), host_info.get_host());
-    host_info = host_selector.get_host(hosts, false, props);
-    EXPECT_EQ(reader_host_info_a.get_host(), host_info.get_host());
+    HostInfo host_info = host_selector.GetHost(hosts, false, props);
+    EXPECT_EQ(reader_host_info_a.GetHost(), host_info.GetHost());
+    host_info = host_selector.GetHost(hosts, false, props);
+    EXPECT_EQ(reader_host_info_a.GetHost(), host_info.GetHost());
 
-    host_info = host_selector.get_host(hosts, false, props);
-    EXPECT_EQ(reader_host_info_b.get_host(), host_info.get_host());
+    host_info = host_selector.GetHost(hosts, false, props);
+    EXPECT_EQ(reader_host_info_b.GetHost(), host_info.GetHost());
 
-    host_info = host_selector.get_host(hosts, false, props);
-    EXPECT_EQ(reader_host_info_a.get_host(), host_info.get_host());
+    host_info = host_selector.GetHost(hosts, false, props);
+    EXPECT_EQ(reader_host_info_a.GetHost(), host_info.GetHost());
 
     std::unordered_map<std::string, std::string> updated_props;
     updated_props[round_robin_property::HOST_WEIGHT_KEY] = std::string(
-        reader_host_info_a.get_host() + ":1"
-         + "," + reader_host_info_b.get_host() + ":2"
+        reader_host_info_a.GetHost() + ":1"
+         + "," + reader_host_info_b.GetHost() + ":2"
     );
 
-    host_info = host_selector.get_host(hosts, false, updated_props);
-    EXPECT_EQ(reader_host_info_a.get_host(), host_info.get_host());
+    host_info = host_selector.GetHost(hosts, false, updated_props);
+    EXPECT_EQ(reader_host_info_a.GetHost(), host_info.GetHost());
 
-    host_info = host_selector.get_host(hosts, false, updated_props);
-    EXPECT_EQ(reader_host_info_b.get_host(), host_info.get_host());
-    host_info = host_selector.get_host(hosts, false, updated_props);
-    EXPECT_EQ(reader_host_info_b.get_host(), host_info.get_host());
+    host_info = host_selector.GetHost(hosts, false, updated_props);
+    EXPECT_EQ(reader_host_info_b.GetHost(), host_info.GetHost());
+    host_info = host_selector.GetHost(hosts, false, updated_props);
+    EXPECT_EQ(reader_host_info_b.GetHost(), host_info.GetHost());
 
-    host_info = host_selector.get_host(hosts, false, updated_props);
-    EXPECT_EQ(reader_host_info_a.get_host(), host_info.get_host());
+    host_info = host_selector.GetHost(hosts, false, updated_props);
+    EXPECT_EQ(reader_host_info_a.GetHost(), host_info.GetHost());
 }
 
 TEST_F(RoundRobinHostSelectorTest, set_round_robin_weight) {
     RoundRobinHostSelector host_selector;
     std::unordered_map<std::string, std::string> props;
     std::string expected_weight_prop(
-        reader_host_info_a.get_host() + ":" + std::to_string(reader_host_info_a.get_weight())
-         + "," + reader_host_info_b.get_host() + ":" + std::to_string(reader_host_info_b.get_weight())
+        reader_host_info_a.GetHost() + ":" + std::to_string(reader_host_info_a.GetWeight())
+         + "," + reader_host_info_b.GetHost() + ":" + std::to_string(reader_host_info_b.GetWeight())
     );
     std::vector<HostInfo> hosts = {reader_host_info_a, reader_host_info_b};
-    RoundRobinHostSelector::set_round_robin_weight(hosts, props);
+    RoundRobinHostSelector::SetRoundRobinWeight(hosts, props);
 
     std::string weight_prop = props.at(round_robin_property::HOST_WEIGHT_KEY);
     EXPECT_STREQ(expected_weight_prop.c_str(), weight_prop.c_str());
 
-    HostInfo host_info = host_selector.get_host(hosts, false, props);
-    EXPECT_EQ(reader_host_info_a.get_host(), host_info.get_host());
+    HostInfo host_info = host_selector.GetHost(hosts, false, props);
+    EXPECT_EQ(reader_host_info_a.GetHost(), host_info.GetHost());
 
-    host_info = host_selector.get_host(hosts, false, props);
-    EXPECT_EQ(reader_host_info_b.get_host(), host_info.get_host());
+    host_info = host_selector.GetHost(hosts, false, props);
+    EXPECT_EQ(reader_host_info_b.GetHost(), host_info.GetHost());
 
-    host_info = host_selector.get_host(hosts, false, props);
-    EXPECT_EQ(reader_host_info_a.get_host(), host_info.get_host());
+    host_info = host_selector.GetHost(hosts, false, props);
+    EXPECT_EQ(reader_host_info_a.GetHost(), host_info.GetHost());
 }
 
 TEST_F(RoundRobinHostSelectorTest, invalid_host_weight_empty_host) {
     RoundRobinHostSelector host_selector;
     std::unordered_map<std::string, std::string> props;
     props[round_robin_property::HOST_WEIGHT_KEY] = std::string(
-        ":" + std::to_string(reader_host_info_a.get_weight())
-         + "," + reader_host_info_b.get_host() + ":" + std::to_string(reader_host_info_b.get_weight())
+        ":" + std::to_string(reader_host_info_a.GetWeight())
+         + "," + reader_host_info_b.GetHost() + ":" + std::to_string(reader_host_info_b.GetWeight())
     );
     std::vector<HostInfo> hosts = {reader_host_info_a, reader_host_info_b};
-    EXPECT_THROW(host_selector.get_host(hosts, false, props), std::runtime_error);
+    EXPECT_THROW(host_selector.GetHost(hosts, false, props), std::runtime_error);
 }
 
 TEST_F(RoundRobinHostSelectorTest, invalid_host_weight_empty_weight) {
     RoundRobinHostSelector host_selector;
     std::unordered_map<std::string, std::string> props;
     props[round_robin_property::HOST_WEIGHT_KEY] = std::string(
-        reader_host_info_a.get_host() + ":"
-         + "," + reader_host_info_b.get_host() + ":" + std::to_string(reader_host_info_b.get_weight())
+        reader_host_info_a.GetHost() + ":"
+         + "," + reader_host_info_b.GetHost() + ":" + std::to_string(reader_host_info_b.GetWeight())
     );
     std::vector<HostInfo> hosts = {reader_host_info_a, reader_host_info_b};
-    EXPECT_THROW(host_selector.get_host(hosts, false, props), std::runtime_error);
+    EXPECT_THROW(host_selector.GetHost(hosts, false, props), std::runtime_error);
 }
 
 TEST_F(RoundRobinHostSelectorTest, invalid_host_weight_zero_weight) {
     RoundRobinHostSelector host_selector;
     std::unordered_map<std::string, std::string> props;
     props[round_robin_property::HOST_WEIGHT_KEY] = std::string(
-        reader_host_info_a.get_host() + ":0"
-         + "," + reader_host_info_b.get_host() + ":" + std::to_string(reader_host_info_b.get_weight())
+        reader_host_info_a.GetHost() + ":0"
+         + "," + reader_host_info_b.GetHost() + ":" + std::to_string(reader_host_info_b.GetWeight())
     );
     std::vector<HostInfo> hosts = {reader_host_info_a, reader_host_info_b};
-    EXPECT_THROW(host_selector.get_host(hosts, false, props), std::runtime_error);
+    EXPECT_THROW(host_selector.GetHost(hosts, false, props), std::runtime_error);
 }
 
 TEST_F(RoundRobinHostSelectorTest, invalid_host_weight_negative_weight) {
     RoundRobinHostSelector host_selector;
     std::unordered_map<std::string, std::string> props;
     props[round_robin_property::HOST_WEIGHT_KEY] = std::string(
-        reader_host_info_a.get_host() + ":-1"
-         + "," + reader_host_info_b.get_host() + ":" + std::to_string(reader_host_info_b.get_weight())
+        reader_host_info_a.GetHost() + ":-1"
+         + "," + reader_host_info_b.GetHost() + ":" + std::to_string(reader_host_info_b.GetWeight())
     );
     std::vector<HostInfo> hosts = {reader_host_info_a, reader_host_info_b};
-    EXPECT_THROW(host_selector.get_host(hosts, false, props), std::runtime_error);
+    EXPECT_THROW(host_selector.GetHost(hosts, false, props), std::runtime_error);
 }
 
 TEST_F(RoundRobinHostSelectorTest, invalid_host_weight_float_weight) {
     RoundRobinHostSelector host_selector;
     std::unordered_map<std::string, std::string> props;
     props[round_robin_property::HOST_WEIGHT_KEY] = std::string(
-        reader_host_info_a.get_host() + ":1.1"
-         + "," + reader_host_info_b.get_host() + ":" + std::to_string(reader_host_info_b.get_weight())
+        reader_host_info_a.GetHost() + ":1.1"
+         + "," + reader_host_info_b.GetHost() + ":" + std::to_string(reader_host_info_b.GetWeight())
     );
     std::vector<HostInfo> hosts = {reader_host_info_a, reader_host_info_b};
-    EXPECT_THROW(host_selector.get_host(hosts, false, props), std::runtime_error);
+    EXPECT_THROW(host_selector.GetHost(hosts, false, props), std::runtime_error);
 }
 
 TEST_F(RoundRobinHostSelectorTest, invalid_host_weight_non_int_weight) {
     RoundRobinHostSelector host_selector;
     std::unordered_map<std::string, std::string> props;
     props[round_robin_property::HOST_WEIGHT_KEY] = std::string(
-        reader_host_info_a.get_host() + ":one"
-         + "," + reader_host_info_b.get_host() + ":" + std::to_string(reader_host_info_b.get_weight())
+        reader_host_info_a.GetHost() + ":one"
+         + "," + reader_host_info_b.GetHost() + ":" + std::to_string(reader_host_info_b.GetWeight())
     );
     std::vector<HostInfo> hosts = {reader_host_info_a, reader_host_info_b};
-    EXPECT_THROW(host_selector.get_host(hosts, false, props), std::runtime_error);
+    EXPECT_THROW(host_selector.GetHost(hosts, false, props), std::runtime_error);
 }
 
 TEST_F(RoundRobinHostSelectorTest, invalid_host_weight_format) {
     RoundRobinHostSelector host_selector;
     std::unordered_map<std::string, std::string> props;
     props[round_robin_property::HOST_WEIGHT_KEY] = std::string(
-        reader_host_info_a.get_host() + ":111:" + std::to_string(reader_host_info_a.get_weight())
-         + "," + reader_host_info_b.get_host() + ":" + std::to_string(reader_host_info_b.get_weight())
+        reader_host_info_a.GetHost() + ":111:" + std::to_string(reader_host_info_a.GetWeight())
+         + "," + reader_host_info_b.GetHost() + ":" + std::to_string(reader_host_info_b.GetWeight())
     );
     std::vector<HostInfo> hosts = {reader_host_info_a, reader_host_info_b};
-    EXPECT_THROW(host_selector.get_host(hosts, false, props), std::runtime_error);
+    EXPECT_THROW(host_selector.GetHost(hosts, false, props), std::runtime_error);
 }
 
 TEST_F(RoundRobinHostSelectorTest, invalid_default_zero) {
@@ -264,7 +264,7 @@ TEST_F(RoundRobinHostSelectorTest, invalid_default_zero) {
     std::unordered_map<std::string, std::string> props;
     props[round_robin_property::DEFAULT_WEIGHT_KEY] = std::string("0");
     std::vector<HostInfo> hosts = {reader_host_info_a, reader_host_info_b};
-    EXPECT_THROW(host_selector.get_host(hosts, false, props), std::runtime_error);
+    EXPECT_THROW(host_selector.GetHost(hosts, false, props), std::runtime_error);
 }
 
 TEST_F(RoundRobinHostSelectorTest, invalid_default_negative) {
@@ -272,7 +272,7 @@ TEST_F(RoundRobinHostSelectorTest, invalid_default_negative) {
     std::unordered_map<std::string, std::string> props;
     props[round_robin_property::DEFAULT_WEIGHT_KEY] = std::string("-100");
     std::vector<HostInfo> hosts = {reader_host_info_a, reader_host_info_b};
-    EXPECT_THROW(host_selector.get_host(hosts, false, props), std::runtime_error);
+    EXPECT_THROW(host_selector.GetHost(hosts, false, props), std::runtime_error);
 }
 
 TEST_F(RoundRobinHostSelectorTest, invalid_default_float) {
@@ -280,7 +280,7 @@ TEST_F(RoundRobinHostSelectorTest, invalid_default_float) {
     std::unordered_map<std::string, std::string> props;
     props[round_robin_property::DEFAULT_WEIGHT_KEY] = std::string("1.1");
     std::vector<HostInfo> hosts = {reader_host_info_a, reader_host_info_b};
-    EXPECT_THROW(host_selector.get_host(hosts, false, props), std::runtime_error);
+    EXPECT_THROW(host_selector.GetHost(hosts, false, props), std::runtime_error);
 }
 
 TEST_F(RoundRobinHostSelectorTest, invalid_default_non_int) {
@@ -288,6 +288,6 @@ TEST_F(RoundRobinHostSelectorTest, invalid_default_non_int) {
     std::unordered_map<std::string, std::string> props;
     props[round_robin_property::DEFAULT_WEIGHT_KEY] = std::string("one");
     std::vector<HostInfo> hosts = {reader_host_info_a, reader_host_info_b};
-    EXPECT_THROW(host_selector.get_host(hosts, false, props), std::runtime_error);
+    EXPECT_THROW(host_selector.GetHost(hosts, false, props), std::runtime_error);
 }
 

--- a/test/unit_test/limitless/limitless_monitor_service_test.cc
+++ b/test/unit_test/limitless/limitless_monitor_service_test.cc
@@ -82,7 +82,7 @@ TEST_F(LimitlessMonitorServiceTest, SingleMonitorTest) {
     std::shared_ptr<HostInfo> host_info = limitless_monitor_service.GetHostInfo(test_service_id);
     EXPECT_TRUE(host_info != nullptr);
     if (host_info != nullptr) {
-        EXPECT_EQ(host_info->get_host(), "test_host1");
+        EXPECT_EQ(host_info->GetHost(), "test_host1");
     }
 
     limitless_monitor_service.DecrementReferenceCounter(test_service_id);
@@ -134,13 +134,13 @@ TEST_F(LimitlessMonitorServiceTest, MultipleMonitorTest) {
     std::shared_ptr<HostInfo> host_info = limitless_monitor_service.GetHostInfo(mock_monitor1_id);
     EXPECT_TRUE(host_info != nullptr);
     if (host_info != nullptr) {
-        EXPECT_EQ(host_info->get_host(), "correct1");
+        EXPECT_EQ(host_info->GetHost(), "correct1");
         host_info = nullptr; // free it
     }
     host_info = limitless_monitor_service.GetHostInfo(mock_monitor2_id);
     EXPECT_TRUE(host_info != nullptr);
     if (host_info != nullptr) {
-        EXPECT_EQ(host_info->get_host(), "correct2");
+        EXPECT_EQ(host_info->GetHost(), "correct2");
         host_info = nullptr; // free it
     }
     host_info = limitless_monitor_service.GetHostInfo(mock_monitor3_id);
@@ -185,7 +185,7 @@ TEST_F(LimitlessMonitorServiceTest, ImmediateMonitorTest) {
     std::shared_ptr<HostInfo> host_info = limitless_monitor_service.GetHostInfo(test_service_id);
     EXPECT_TRUE(host_info != nullptr);
     if (host_info != nullptr) {
-        EXPECT_EQ(host_info->get_host(), "test_host1");
+        EXPECT_EQ(host_info->GetHost(), "test_host1");
     }
 
     limitless_monitor_service.DecrementReferenceCounter(test_service_id);

--- a/test/unit_test/main.cc
+++ b/test/unit_test/main.cc
@@ -16,7 +16,7 @@
 #include <logger_wrapper.h>
 
 int main(int argc, char** argv) {
-  LoggerWrapper::initialize();
+  LoggerWrapper::Initialize();
 
 #ifdef WIN32
 #ifdef _DEBUG

--- a/test/unit_test/mock_objects.h
+++ b/test/unit_test/mock_objects.h
@@ -134,10 +134,10 @@ public:
 class MOCK_CLUSTER_TOPOLOGY_QUERY_HELPER : public ClusterTopologyQueryHelper {
 public:
     MOCK_CLUSTER_TOPOLOGY_QUERY_HELPER() : ClusterTopologyQueryHelper(0, "", "", "", "") {}
-    MOCK_METHOD(std::string, get_writer_id, (SQLHDBC), ());
-    MOCK_METHOD(std::string, get_node_id, (SQLHDBC), ());
-    MOCK_METHOD(std::vector<HostInfo>, query_topology, (SQLHDBC), ());
-    MOCK_METHOD(HostInfo, create_host, (SQLHDBC), ());
+    MOCK_METHOD(std::string, GetWriterId, (SQLHDBC), ());
+    MOCK_METHOD(std::string, GetNodeId, (SQLHDBC), ());
+    MOCK_METHOD(std::vector<HostInfo>, QueryTopology, (SQLHDBC), ());
+    MOCK_METHOD(HostInfo, CreateHost, (SQLHDBC), ());
 };
 
 #endif /* __MOCKOBJECTS_H__ */

--- a/test/unit_test/util/rds_utils_test.cc
+++ b/test/unit_test/util/rds_utils_test.cc
@@ -44,114 +44,114 @@ class RdsUtilsTest : public testing::Test {
     void TearDown() override {}
 };
 
-TEST_F(RdsUtilsTest, is_rds_dns) {
-    EXPECT_TRUE(RdsUtils::is_rds_dns(US_EAST_REGION_CLUSTER));
-    EXPECT_TRUE(RdsUtils::is_rds_dns(US_EAST_REGION_CLUSTER_READ_ONLY));
-    EXPECT_TRUE(RdsUtils::is_rds_dns(US_EAST_REGION_PROXY));
-    EXPECT_TRUE(RdsUtils::is_rds_dns(US_EAST_REGION_CUSTON_DOMAIN));
+TEST_F(RdsUtilsTest, IsRdsDns) {
+    EXPECT_TRUE(RdsUtils::IsRdsDns(US_EAST_REGION_CLUSTER));
+    EXPECT_TRUE(RdsUtils::IsRdsDns(US_EAST_REGION_CLUSTER_READ_ONLY));
+    EXPECT_TRUE(RdsUtils::IsRdsDns(US_EAST_REGION_PROXY));
+    EXPECT_TRUE(RdsUtils::IsRdsDns(US_EAST_REGION_CUSTON_DOMAIN));
 
-    EXPECT_TRUE(RdsUtils::is_rds_dns(CHINA_REGION_CLUSTER));
-    EXPECT_TRUE(RdsUtils::is_rds_dns(CHINA_REGION_CLUSTER_READ_ONLY));
-    EXPECT_TRUE(RdsUtils::is_rds_dns(CHINA_REGION_PROXY));
-    EXPECT_TRUE(RdsUtils::is_rds_dns(CHINA_REGION_CUSTON_DOMAIN));
+    EXPECT_TRUE(RdsUtils::IsRdsDns(CHINA_REGION_CLUSTER));
+    EXPECT_TRUE(RdsUtils::IsRdsDns(CHINA_REGION_CLUSTER_READ_ONLY));
+    EXPECT_TRUE(RdsUtils::IsRdsDns(CHINA_REGION_PROXY));
+    EXPECT_TRUE(RdsUtils::IsRdsDns(CHINA_REGION_CUSTON_DOMAIN));
 }
 
-TEST_F(RdsUtilsTest, is_rds_cluster_dns) {
-    EXPECT_TRUE(RdsUtils::is_rds_cluster_dns(US_EAST_REGION_CLUSTER));
-    EXPECT_TRUE(RdsUtils::is_rds_cluster_dns(US_EAST_REGION_CLUSTER_READ_ONLY));
-    EXPECT_FALSE(RdsUtils::is_rds_cluster_dns(US_EAST_REGION_PROXY));
-    EXPECT_FALSE(RdsUtils::is_rds_cluster_dns(US_EAST_REGION_CUSTON_DOMAIN));
+TEST_F(RdsUtilsTest, IsRdsClusterDns) {
+    EXPECT_TRUE(RdsUtils::IsRdsClusterDns(US_EAST_REGION_CLUSTER));
+    EXPECT_TRUE(RdsUtils::IsRdsClusterDns(US_EAST_REGION_CLUSTER_READ_ONLY));
+    EXPECT_FALSE(RdsUtils::IsRdsClusterDns(US_EAST_REGION_PROXY));
+    EXPECT_FALSE(RdsUtils::IsRdsClusterDns(US_EAST_REGION_CUSTON_DOMAIN));
 
-    EXPECT_TRUE(RdsUtils::is_rds_cluster_dns(CHINA_REGION_CLUSTER));
-    EXPECT_TRUE(RdsUtils::is_rds_cluster_dns(CHINA_REGION_CLUSTER_READ_ONLY));
-    EXPECT_FALSE(RdsUtils::is_rds_cluster_dns(CHINA_REGION_PROXY));
-    EXPECT_FALSE(RdsUtils::is_rds_cluster_dns(CHINA_REGION_CUSTON_DOMAIN));
+    EXPECT_TRUE(RdsUtils::IsRdsClusterDns(CHINA_REGION_CLUSTER));
+    EXPECT_TRUE(RdsUtils::IsRdsClusterDns(CHINA_REGION_CLUSTER_READ_ONLY));
+    EXPECT_FALSE(RdsUtils::IsRdsClusterDns(CHINA_REGION_PROXY));
+    EXPECT_FALSE(RdsUtils::IsRdsClusterDns(CHINA_REGION_CUSTON_DOMAIN));
 }
 
-TEST_F(RdsUtilsTest, is_rds_proxy_dns) {
-    EXPECT_FALSE(RdsUtils::is_rds_proxy_dns(US_EAST_REGION_CLUSTER));
-    EXPECT_FALSE(RdsUtils::is_rds_proxy_dns(US_EAST_REGION_CLUSTER_READ_ONLY));
-    EXPECT_TRUE(RdsUtils::is_rds_proxy_dns(US_EAST_REGION_PROXY));
-    EXPECT_FALSE(RdsUtils::is_rds_proxy_dns(US_EAST_REGION_CUSTON_DOMAIN));
+TEST_F(RdsUtilsTest, IsRdsProxyDns) {
+    EXPECT_FALSE(RdsUtils::IsRdsProxyDns(US_EAST_REGION_CLUSTER));
+    EXPECT_FALSE(RdsUtils::IsRdsProxyDns(US_EAST_REGION_CLUSTER_READ_ONLY));
+    EXPECT_TRUE(RdsUtils::IsRdsProxyDns(US_EAST_REGION_PROXY));
+    EXPECT_FALSE(RdsUtils::IsRdsProxyDns(US_EAST_REGION_CUSTON_DOMAIN));
 
-    EXPECT_FALSE(RdsUtils::is_rds_proxy_dns(CHINA_REGION_CLUSTER));
-    EXPECT_FALSE(RdsUtils::is_rds_proxy_dns(CHINA_REGION_CLUSTER_READ_ONLY));
-    EXPECT_TRUE(RdsUtils::is_rds_proxy_dns(CHINA_REGION_PROXY));
-    EXPECT_FALSE(RdsUtils::is_rds_proxy_dns(CHINA_REGION_CUSTON_DOMAIN));
+    EXPECT_FALSE(RdsUtils::IsRdsProxyDns(CHINA_REGION_CLUSTER));
+    EXPECT_FALSE(RdsUtils::IsRdsProxyDns(CHINA_REGION_CLUSTER_READ_ONLY));
+    EXPECT_TRUE(RdsUtils::IsRdsProxyDns(CHINA_REGION_PROXY));
+    EXPECT_FALSE(RdsUtils::IsRdsProxyDns(CHINA_REGION_CUSTON_DOMAIN));
 }
 
-TEST_F(RdsUtilsTest, is_rds_writer_cluster_dns) {
-    EXPECT_TRUE(RdsUtils::is_rds_writer_cluster_dns(US_EAST_REGION_CLUSTER));
-    EXPECT_FALSE(RdsUtils::is_rds_writer_cluster_dns(US_EAST_REGION_CLUSTER_READ_ONLY));
-    EXPECT_FALSE(RdsUtils::is_rds_writer_cluster_dns(US_EAST_REGION_PROXY));
-    EXPECT_FALSE(RdsUtils::is_rds_writer_cluster_dns(US_EAST_REGION_CUSTON_DOMAIN));
+TEST_F(RdsUtilsTest, IsRdsWriterClusterDns) {
+    EXPECT_TRUE(RdsUtils::IsRdsWriterClusterDns(US_EAST_REGION_CLUSTER));
+    EXPECT_FALSE(RdsUtils::IsRdsWriterClusterDns(US_EAST_REGION_CLUSTER_READ_ONLY));
+    EXPECT_FALSE(RdsUtils::IsRdsWriterClusterDns(US_EAST_REGION_PROXY));
+    EXPECT_FALSE(RdsUtils::IsRdsWriterClusterDns(US_EAST_REGION_CUSTON_DOMAIN));
 
-    EXPECT_TRUE(RdsUtils::is_rds_writer_cluster_dns(CHINA_REGION_CLUSTER));
-    EXPECT_FALSE(RdsUtils::is_rds_writer_cluster_dns(CHINA_REGION_CLUSTER_READ_ONLY));
-    EXPECT_FALSE(RdsUtils::is_rds_writer_cluster_dns(CHINA_REGION_PROXY));
-    EXPECT_FALSE(RdsUtils::is_rds_writer_cluster_dns(CHINA_REGION_CUSTON_DOMAIN));
+    EXPECT_TRUE(RdsUtils::IsRdsWriterClusterDns(CHINA_REGION_CLUSTER));
+    EXPECT_FALSE(RdsUtils::IsRdsWriterClusterDns(CHINA_REGION_CLUSTER_READ_ONLY));
+    EXPECT_FALSE(RdsUtils::IsRdsWriterClusterDns(CHINA_REGION_PROXY));
+    EXPECT_FALSE(RdsUtils::IsRdsWriterClusterDns(CHINA_REGION_CUSTON_DOMAIN));
 }
 
-TEST_F(RdsUtilsTest, id_rds_custom_cluster) {
-    EXPECT_FALSE(RdsUtils::is_rds_custom_cluster_dns(US_EAST_REGION_CLUSTER));
-    EXPECT_FALSE(RdsUtils::is_rds_custom_cluster_dns(US_EAST_REGION_CLUSTER_READ_ONLY));
-    EXPECT_FALSE(RdsUtils::is_rds_custom_cluster_dns(US_EAST_REGION_PROXY));
-    EXPECT_TRUE(RdsUtils::is_rds_custom_cluster_dns(US_EAST_REGION_CUSTON_DOMAIN));
+TEST_F(RdsUtilsTest, IsRdsCustomClusterDns) {
+    EXPECT_FALSE(RdsUtils::IsRdsCustomClusterDns(US_EAST_REGION_CLUSTER));
+    EXPECT_FALSE(RdsUtils::IsRdsCustomClusterDns(US_EAST_REGION_CLUSTER_READ_ONLY));
+    EXPECT_FALSE(RdsUtils::IsRdsCustomClusterDns(US_EAST_REGION_PROXY));
+    EXPECT_TRUE(RdsUtils::IsRdsCustomClusterDns(US_EAST_REGION_CUSTON_DOMAIN));
 
-    EXPECT_FALSE(RdsUtils::is_rds_custom_cluster_dns(CHINA_REGION_CLUSTER));
-    EXPECT_FALSE(RdsUtils::is_rds_custom_cluster_dns(CHINA_REGION_CLUSTER_READ_ONLY));
-    EXPECT_FALSE(RdsUtils::is_rds_custom_cluster_dns(CHINA_REGION_PROXY));
-    EXPECT_TRUE(RdsUtils::is_rds_custom_cluster_dns(CHINA_REGION_CUSTON_DOMAIN));
+    EXPECT_FALSE(RdsUtils::IsRdsCustomClusterDns(CHINA_REGION_CLUSTER));
+    EXPECT_FALSE(RdsUtils::IsRdsCustomClusterDns(CHINA_REGION_CLUSTER_READ_ONLY));
+    EXPECT_FALSE(RdsUtils::IsRdsCustomClusterDns(CHINA_REGION_PROXY));
+    EXPECT_TRUE(RdsUtils::IsRdsCustomClusterDns(CHINA_REGION_CUSTON_DOMAIN));
 }
 
-TEST_F(RdsUtilsTest, get_rds_instance_host_pattern) {
+TEST_F(RdsUtilsTest, GetRdsInstanceHostPattern) {
     const std::string expected_pattern = "?.XYZ.us-east-2.rds.amazonaws.com";
-    EXPECT_EQ(expected_pattern, RdsUtils::get_rds_instance_host_pattern(US_EAST_REGION_CLUSTER));
-    EXPECT_EQ(expected_pattern, RdsUtils::get_rds_instance_host_pattern(US_EAST_REGION_CLUSTER_READ_ONLY));
-    EXPECT_EQ(expected_pattern, RdsUtils::get_rds_instance_host_pattern(US_EAST_REGION_PROXY));
-    EXPECT_EQ(expected_pattern, RdsUtils::get_rds_instance_host_pattern(US_EAST_REGION_CUSTON_DOMAIN));
+    EXPECT_EQ(expected_pattern, RdsUtils::GetRdsInstanceHostPattern(US_EAST_REGION_CLUSTER));
+    EXPECT_EQ(expected_pattern, RdsUtils::GetRdsInstanceHostPattern(US_EAST_REGION_CLUSTER_READ_ONLY));
+    EXPECT_EQ(expected_pattern, RdsUtils::GetRdsInstanceHostPattern(US_EAST_REGION_PROXY));
+    EXPECT_EQ(expected_pattern, RdsUtils::GetRdsInstanceHostPattern(US_EAST_REGION_CUSTON_DOMAIN));
 
     const std::string expected_china_pattern = "?.XYZ.rds.cn-northwest-1.amazonaws.com.cn";
-    EXPECT_EQ(expected_china_pattern, RdsUtils::get_rds_instance_host_pattern(CHINA_REGION_CLUSTER));
-    EXPECT_EQ(expected_china_pattern, RdsUtils::get_rds_instance_host_pattern(CHINA_REGION_CLUSTER_READ_ONLY));
-    EXPECT_EQ(expected_china_pattern, RdsUtils::get_rds_instance_host_pattern(CHINA_REGION_PROXY));
-    EXPECT_EQ(expected_china_pattern, RdsUtils::get_rds_instance_host_pattern(CHINA_REGION_CUSTON_DOMAIN));
+    EXPECT_EQ(expected_china_pattern, RdsUtils::GetRdsInstanceHostPattern(CHINA_REGION_CLUSTER));
+    EXPECT_EQ(expected_china_pattern, RdsUtils::GetRdsInstanceHostPattern(CHINA_REGION_CLUSTER_READ_ONLY));
+    EXPECT_EQ(expected_china_pattern, RdsUtils::GetRdsInstanceHostPattern(CHINA_REGION_PROXY));
+    EXPECT_EQ(expected_china_pattern, RdsUtils::GetRdsInstanceHostPattern(CHINA_REGION_CUSTON_DOMAIN));
 }
 
-TEST_F(RdsUtilsTest, get_rds_cluster_host_url) {
-    EXPECT_EQ(US_EAST_REGION_CLUSTER, RdsUtils::get_rds_cluster_host_url(US_EAST_REGION_CLUSTER));
-    EXPECT_EQ(US_EAST_REGION_CLUSTER, RdsUtils::get_rds_cluster_host_url(US_EAST_REGION_CLUSTER_READ_ONLY));
-    EXPECT_EQ(std::string(), RdsUtils::get_rds_cluster_host_url(US_EAST_REGION_PROXY));
-    EXPECT_EQ(std::string(), RdsUtils::get_rds_cluster_host_url(US_EAST_REGION_CUSTON_DOMAIN));
+TEST_F(RdsUtilsTest, GetRdsClusterHostUrl) {
+    EXPECT_EQ(US_EAST_REGION_CLUSTER, RdsUtils::GetRdsClusterHostUrl(US_EAST_REGION_CLUSTER));
+    EXPECT_EQ(US_EAST_REGION_CLUSTER, RdsUtils::GetRdsClusterHostUrl(US_EAST_REGION_CLUSTER_READ_ONLY));
+    EXPECT_EQ(std::string(), RdsUtils::GetRdsClusterHostUrl(US_EAST_REGION_PROXY));
+    EXPECT_EQ(std::string(), RdsUtils::GetRdsClusterHostUrl(US_EAST_REGION_CUSTON_DOMAIN));
 
-    EXPECT_EQ(CHINA_REGION_CLUSTER, RdsUtils::get_rds_cluster_host_url(CHINA_REGION_CLUSTER));
-    EXPECT_EQ(CHINA_REGION_CLUSTER, RdsUtils::get_rds_cluster_host_url(CHINA_REGION_CLUSTER_READ_ONLY));
-    EXPECT_EQ(std::string(), RdsUtils::get_rds_cluster_host_url(CHINA_REGION_PROXY));
-    EXPECT_EQ(std::string(), RdsUtils::get_rds_cluster_host_url(CHINA_REGION_CUSTON_DOMAIN));
+    EXPECT_EQ(CHINA_REGION_CLUSTER, RdsUtils::GetRdsClusterHostUrl(CHINA_REGION_CLUSTER));
+    EXPECT_EQ(CHINA_REGION_CLUSTER, RdsUtils::GetRdsClusterHostUrl(CHINA_REGION_CLUSTER_READ_ONLY));
+    EXPECT_EQ(std::string(), RdsUtils::GetRdsClusterHostUrl(CHINA_REGION_PROXY));
+    EXPECT_EQ(std::string(), RdsUtils::GetRdsClusterHostUrl(CHINA_REGION_CUSTON_DOMAIN));
 }
 
-TEST_F(RdsUtilsTest, get_rds_cluster_id) {
-    EXPECT_EQ("database-test-name", RdsUtils::get_rds_cluster_id(US_EAST_REGION_CLUSTER));
-    EXPECT_EQ("database-test-name", RdsUtils::get_rds_cluster_id(US_EAST_REGION_CLUSTER_READ_ONLY));
-    EXPECT_EQ(std::string(), RdsUtils::get_rds_cluster_id(US_EAST_REGION_INSTANCE));
+TEST_F(RdsUtilsTest, GetRdsClusterId) {
+    EXPECT_EQ("database-test-name", RdsUtils::GetRdsClusterId(US_EAST_REGION_CLUSTER));
+    EXPECT_EQ("database-test-name", RdsUtils::GetRdsClusterId(US_EAST_REGION_CLUSTER_READ_ONLY));
+    EXPECT_EQ(std::string(), RdsUtils::GetRdsClusterId(US_EAST_REGION_INSTANCE));
 
-    EXPECT_EQ("proxy-test-name", RdsUtils::get_rds_cluster_id(US_EAST_REGION_PROXY));
-    EXPECT_EQ("custom-test-name", RdsUtils::get_rds_cluster_id(US_EAST_REGION_CUSTON_DOMAIN));
+    EXPECT_EQ("proxy-test-name", RdsUtils::GetRdsClusterId(US_EAST_REGION_PROXY));
+    EXPECT_EQ("custom-test-name", RdsUtils::GetRdsClusterId(US_EAST_REGION_CUSTON_DOMAIN));
 
-    EXPECT_EQ("database-test-name", RdsUtils::get_rds_cluster_id(CHINA_REGION_CLUSTER));
-    EXPECT_EQ("database-test-name", RdsUtils::get_rds_cluster_id(CHINA_REGION_CLUSTER_READ_ONLY));
-    EXPECT_EQ("proxy-test-name", RdsUtils::get_rds_cluster_id(CHINA_REGION_PROXY));
-    EXPECT_EQ("custom-test-name", RdsUtils::get_rds_cluster_id(CHINA_REGION_CUSTON_DOMAIN));
+    EXPECT_EQ("database-test-name", RdsUtils::GetRdsClusterId(CHINA_REGION_CLUSTER));
+    EXPECT_EQ("database-test-name", RdsUtils::GetRdsClusterId(CHINA_REGION_CLUSTER_READ_ONLY));
+    EXPECT_EQ("proxy-test-name", RdsUtils::GetRdsClusterId(CHINA_REGION_PROXY));
+    EXPECT_EQ("custom-test-name", RdsUtils::GetRdsClusterId(CHINA_REGION_CUSTON_DOMAIN));
 }
 
-TEST_F(RdsUtilsTest, get_rds_instance_id) {
-    EXPECT_EQ("instance-test-name", RdsUtils::get_rds_instance_id(US_EAST_REGION_INSTANCE));
-    EXPECT_EQ(std::string(), RdsUtils::get_rds_instance_id(US_EAST_REGION_CLUSTER_READ_ONLY));
-    EXPECT_EQ(std::string(), RdsUtils::get_rds_instance_id(US_EAST_REGION_CLUSTER));
+TEST_F(RdsUtilsTest, GetRdsInstanceId) {
+    EXPECT_EQ("instance-test-name", RdsUtils::GetRdsInstanceId(US_EAST_REGION_INSTANCE));
+    EXPECT_EQ(std::string(), RdsUtils::GetRdsInstanceId(US_EAST_REGION_CLUSTER_READ_ONLY));
+    EXPECT_EQ(std::string(), RdsUtils::GetRdsInstanceId(US_EAST_REGION_CLUSTER));
 }
 
 #ifdef WIN32
 TEST_F(RdsUtilsTest, sqlwchar_to_string_converted) {
-    EXPECT_EQ("Wide character string", StringHelper::to_string(L"Wide character string"));
+    EXPECT_EQ("Wide character string", StringHelper::ToString(L"Wide character string"));
 }
 #endif

--- a/test/unit_test/util/sliding_cache_map_test.cc
+++ b/test/unit_test/util/sliding_cache_map_test.cc
@@ -43,116 +43,116 @@ class SlidingCacheMapTest : public testing::Test {
 
 TEST_F(SlidingCacheMapTest, put_cache) {
     SlidingCacheMap<std::string, std::string> cache;
-    cache.put(cache_key_a, cache_val_a);
-    cache.put(cache_key_b, cache_val_b, cache_exp_long);
-    EXPECT_STREQ(cache_val_a.c_str(), cache.get(cache_key_a).c_str());
-    EXPECT_STREQ(cache_val_b.c_str(), cache.get(cache_key_b).c_str());
+    cache.Put(cache_key_a, cache_val_a);
+    cache.Put(cache_key_b, cache_val_b, cache_exp_long);
+    EXPECT_STREQ(cache_val_a.c_str(), cache.Get(cache_key_a).c_str());
+    EXPECT_STREQ(cache_val_b.c_str(), cache.Get(cache_key_b).c_str());
 }
 
 TEST_F(SlidingCacheMapTest, put_cache_update) {
     SlidingCacheMap<std::string, std::string> cache;
-    EXPECT_EQ(0, cache.size());
-    cache.put(cache_key_a, cache_val_a);
-    cache.put(cache_key_b, cache_val_b, cache_exp_short);
-    EXPECT_EQ(2, cache.size());
-    EXPECT_STREQ(cache_val_b.c_str(), cache.get(cache_key_b).c_str());
+    EXPECT_EQ(0, cache.Size());
+    cache.Put(cache_key_a, cache_val_a);
+    cache.Put(cache_key_b, cache_val_b, cache_exp_short);
+    EXPECT_EQ(2, cache.Size());
+    EXPECT_STREQ(cache_val_b.c_str(), cache.Get(cache_key_b).c_str());
 
-    cache.put(cache_key_b, cache_val_b, cache_exp_long);
+    cache.Put(cache_key_b, cache_val_b, cache_exp_long);
     std::this_thread::sleep_for(std::chrono::seconds(cache_exp_mid));
-    EXPECT_EQ(2, cache.size());
-    EXPECT_STREQ(cache_val_b.c_str(), cache.get(cache_key_b).c_str());
+    EXPECT_EQ(2, cache.Size());
+    EXPECT_STREQ(cache_val_b.c_str(), cache.Get(cache_key_b).c_str());
 }
 
 TEST_F(SlidingCacheMapTest, get_cache_hit) {
     SlidingCacheMap<std::string, std::string> cache;
-    cache.put(cache_key_a, cache_val_a);
-    EXPECT_STREQ(cache_val_a.c_str(), cache.get(cache_key_a).c_str());
+    cache.Put(cache_key_a, cache_val_a);
+    EXPECT_STREQ(cache_val_a.c_str(), cache.Get(cache_key_a).c_str());
 }
 
 TEST_F(SlidingCacheMapTest, get_cache_miss) {
     SlidingCacheMap<std::string, std::string> cache;
-    EXPECT_STREQ(cache_empty.c_str(), cache.get(cache_key_a).c_str());
+    EXPECT_STREQ(cache_empty.c_str(), cache.Get(cache_key_a).c_str());
 }
 
 TEST_F(SlidingCacheMapTest, get_cache_expire) {
     SlidingCacheMap<std::string, std::string> cache;
-    cache.put(cache_key_a, cache_val_a, cache_exp_short);
+    cache.Put(cache_key_a, cache_val_a, cache_exp_short);
     std::this_thread::sleep_for(std::chrono::seconds(cache_exp_mid));
-    EXPECT_STREQ(cache_empty.c_str(), cache.get(cache_key_a).c_str());
+    EXPECT_STREQ(cache_empty.c_str(), cache.Get(cache_key_a).c_str());
 }
 
 TEST_F(SlidingCacheMapTest, find_cache_miss) {
     SlidingCacheMap<std::string, std::string> cache;
-    EXPECT_FALSE(cache.find("Missing"));
+    EXPECT_FALSE(cache.Find("Missing"));
 }
 
 TEST_F(SlidingCacheMapTest, find_cache_hit) {
     SlidingCacheMap<std::string, std::string> cache;
-    cache.put(cache_key_a, cache_val_a);
-    EXPECT_TRUE(cache.find(cache_key_a));
+    cache.Put(cache_key_a, cache_val_a);
+    EXPECT_TRUE(cache.Find(cache_key_a));
 }
 
 TEST_F(SlidingCacheMapTest, cache_size) {
     SlidingCacheMap<std::string, std::string> cache;
-    EXPECT_EQ(0, cache.size());
-    cache.put(cache_key_a, cache_val_a);
-    cache.put(cache_key_b, cache_val_b);
-    EXPECT_EQ(2, cache.size());
+    EXPECT_EQ(0, cache.Size());
+    cache.Put(cache_key_a, cache_val_a);
+    cache.Put(cache_key_b, cache_val_b);
+    EXPECT_EQ(2, cache.Size());
 }
 
 TEST_F(SlidingCacheMapTest, cache_size_expire) {
     SlidingCacheMap<std::string, std::string> cache;
-    EXPECT_EQ(0, cache.size());
-    cache.put(cache_key_a, cache_val_a, cache_exp_short);
-    cache.put(cache_key_b, cache_val_b, cache_exp_short);
-    EXPECT_EQ(2, cache.size());
+    EXPECT_EQ(0, cache.Size());
+    cache.Put(cache_key_a, cache_val_a, cache_exp_short);
+    cache.Put(cache_key_b, cache_val_b, cache_exp_short);
+    EXPECT_EQ(2, cache.Size());
     std::this_thread::sleep_for(std::chrono::seconds(cache_exp_mid));
-    EXPECT_EQ(0, cache.size());
+    EXPECT_EQ(0, cache.Size());
 }
 
 TEST_F(SlidingCacheMapTest, cache_clear) {
     SlidingCacheMap<std::string, std::string> cache;
-    cache.put(cache_key_a, cache_val_a);
-    cache.put(cache_key_b, cache_val_b);
-    EXPECT_EQ(2, cache.size());
-    cache.clear();
-    EXPECT_EQ(0, cache.size());
+    cache.Put(cache_key_a, cache_val_a);
+    cache.Put(cache_key_b, cache_val_b);
+    EXPECT_EQ(2, cache.Size());
+    cache.Clear();
+    EXPECT_EQ(0, cache.Size());
 }
 
 TEST_F(SlidingCacheMapTest, ttl_update_find) {
     SlidingCacheMap<std::string, std::string> cache;
-    EXPECT_EQ(0, cache.size());
-    cache.put(cache_key_a, cache_val_a, cache_exp_mid);
-    EXPECT_EQ(1, cache.size());
+    EXPECT_EQ(0, cache.Size());
+    cache.Put(cache_key_a, cache_val_a, cache_exp_mid);
+    EXPECT_EQ(1, cache.Size());
 
     std::this_thread::sleep_for(std::chrono::seconds(cache_exp_short));
 
     // Touch to refresh TTL
-    EXPECT_TRUE(cache.find(cache_key_a));
+    EXPECT_TRUE(cache.Find(cache_key_a));
 
     // Sleep again combined with previous to expire original put
     std::this_thread::sleep_for(std::chrono::seconds(cache_exp_short));
 
     // Should be valid due to earlier `find()` updates TTL
-    EXPECT_EQ(1, cache.size());
-    EXPECT_STREQ(cache_val_a.c_str(), cache.get(cache_key_a).c_str());
+    EXPECT_EQ(1, cache.Size());
+    EXPECT_STREQ(cache_val_a.c_str(), cache.Get(cache_key_a).c_str());
 }
 
 TEST_F(SlidingCacheMapTest, ttl_update_get) {
     SlidingCacheMap<std::string, std::string> cache;
-    EXPECT_EQ(0, cache.size());
-    cache.put(cache_key_a, cache_val_a, cache_exp_mid);
-    EXPECT_EQ(1, cache.size());
+    EXPECT_EQ(0, cache.Size());
+    cache.Put(cache_key_a, cache_val_a, cache_exp_mid);
+    EXPECT_EQ(1, cache.Size());
 
     std::this_thread::sleep_for(std::chrono::seconds(cache_exp_short));
 
     // Touch to refresh TTL
-    EXPECT_STREQ(cache_val_a.c_str(), cache.get(cache_key_a).c_str());
+    EXPECT_STREQ(cache_val_a.c_str(), cache.Get(cache_key_a).c_str());
 
     // Sleep again combined with previous to expire original put
     std::this_thread::sleep_for(std::chrono::seconds(cache_exp_short));
 
     // Should be valid due to earlier `get()` updates TTL
-    EXPECT_EQ(1, cache.size());
-    EXPECT_STREQ(cache_val_a.c_str(), cache.get(cache_key_a).c_str());
+    EXPECT_EQ(1, cache.Size());
+    EXPECT_STREQ(cache_val_a.c_str(), cache.Get(cache_key_a).c_str());
 }


### PR DESCRIPTION
# Summary
Library had inconsistent naming style for methods. Update all methods for consistency.
Naming style based on the oldest files from this library (adfs.h, okta.h, ...)
- public and protected methods use CamelCase
- private methods use snake_case
## Description
<!--- Description of the ticket. e.g., What is the ticket accomplishing, why is it important, what areas of the code does it affect, etc. -->

## Testing
<!--- Steps taken to test this change. e.g. Adding unit tests, integration tests, and/or manual testing -->
