### PR TITLE
fix: actually implement ShutdownRdsLogger

### DIFF
--- a/src/util/rds_logger_service.cc
+++ b/src/util/rds_logger_service.cc
@@ -18,3 +18,7 @@
 void InitializeRdsLogger(const char* log_dir, int threshold) {
     LoggerWrapper::Initialize(log_dir, threshold);
 }
+
+void ShutdownRdsLogger() {
+    LoggerWrapper::Shutdown();
+}


### PR DESCRIPTION
# Summary

Actually implement ShutdownRdsLogger function to call LoggerWrapper::Shutdown.

## Description

Self-explanatory.

## Testing

- [x] Unit tests pass
- [x] Integ tests pass