### PR TITLE
refactor: move odbc calls into library for limitless

### DIFF
--- a/.github/workflows/run_static_analysis.yml
+++ b/.github/workflows/run_static_analysis.yml
@@ -69,3 +69,7 @@ jobs:
         run: |
           source ./venv/bin/activate
           CodeChecker parse --print-steps ./reports
+
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: always()

--- a/.github/workflows/run_static_analysis.yml
+++ b/.github/workflows/run_static_analysis.yml
@@ -69,7 +69,3 @@ jobs:
         run: |
           source ./venv/bin/activate
           CodeChecker parse --print-steps ./reports
-
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: always()

--- a/src/limitless/limitless_monitor_service.cc
+++ b/src/limitless/limitless_monitor_service.cc
@@ -189,9 +189,7 @@ bool CheckLimitlessCluster(const SQLTCHAR *connection_string_c_str) {
         return false;
     }
 
-    // TODO(sfavian): Replace with odbc helper connection from failover PR...
-    SQLRETURN rc = SQLDriverConnect(hdbc, nullptr, const_cast<SQLTCHAR*>(connection_string_c_str), SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
-    if (!OdbcHelper::CheckResult(rc, "ERROR: Could not connect during limitless cluster check", hdbc, SQL_HANDLE_DBC)) {
+    if (!OdbcHelper::ConnStrConnect(const_cast<SQLTCHAR*>(connection_string_c_str), hdbc)) {
         OdbcHelper::Cleanup(henv, hdbc, SQL_NULL_HANDLE);
         return false;
     }

--- a/src/limitless/limitless_monitor_service.cc
+++ b/src/limitless/limitless_monitor_service.cc
@@ -186,7 +186,7 @@ bool CheckLimitlessCluster(const SQLTCHAR *connection_string_c_str, const char *
     if (!OdbcHelper::AllocateHandle(SQL_HANDLE_ENV, nullptr, henv, "Could not allocate environment handle during limitless check") ||
         !OdbcHelper::SetHenvToOdbc3(henv, "Could not set henv to odbc3 during limitless check")) {
         // Set error message and clean up
-        limitless_errmsg = StringHelper::MergeStrings(std::string("Could not allocate environment handle."), custom_errmsg);
+        limitless_errmsg = StringHelper::MergeStrings("Could not allocate environment handle.", custom_errmsg);
         *errmsg_ptr = limitless_errmsg.c_str();
         OdbcHelper::Cleanup(henv, SQL_NULL_HANDLE, SQL_NULL_HANDLE);
         return false;
@@ -194,7 +194,7 @@ bool CheckLimitlessCluster(const SQLTCHAR *connection_string_c_str, const char *
 
     if (!OdbcHelper::AllocateHandle(SQL_HANDLE_DBC, henv, hdbc, "ERROR: could not allocate connection handle during limitless check")) {
         // Set error message and clean up
-        limitless_errmsg = StringHelper::MergeStrings(std::string("Could not allocate connection handle."), custom_errmsg);
+        limitless_errmsg = StringHelper::MergeStrings("Could not allocate connection handle.", custom_errmsg);
         *errmsg_ptr = limitless_errmsg.c_str();
         OdbcHelper::Cleanup(henv, hdbc, SQL_NULL_HANDLE);
         return false;
@@ -207,8 +207,6 @@ bool CheckLimitlessCluster(const SQLTCHAR *connection_string_c_str, const char *
         OdbcHelper::Cleanup(henv, hdbc, SQL_NULL_HANDLE);
         return false;
     }
-
-    *errmsg_ptr = nullptr;
 
     bool is_limitess_cluster = LimitlessQueryHelper::CheckLimitlessCluster(hdbc);
     OdbcHelper::Cleanup(henv, hdbc, SQL_NULL_HANDLE);

--- a/src/limitless/limitless_monitor_service.cc
+++ b/src/limitless/limitless_monitor_service.cc
@@ -190,7 +190,7 @@ bool CheckLimitlessCluster(const SQLTCHAR *connection_string_c_str) {
         return false;
     }
 
-    // TODO: Replace with odbc helper connection from failover PR...
+    // TODO(sfavian): Replace with odbc helper connection from failover PR...
     SQLRETURN rc = SQLDriverConnect(hdbc, nullptr, const_cast<SQLTCHAR*>(connection_string_c_str), SQL_NTS, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
     if (!OdbcHelper::CheckResult(rc, "ERROR: Could not connect during limitless cluster check", hdbc, SQL_HANDLE_DBC)) {
         OdbcHelper::Cleanup(henv, hdbc, SQL_NULL_HANDLE);

--- a/src/limitless/limitless_monitor_service.cc
+++ b/src/limitless/limitless_monitor_service.cc
@@ -20,7 +20,6 @@
 
 #include <cstdio>
 #include <cstring>
-#include <iostream>
 
 #include <glog/logging.h>
 

--- a/src/limitless/limitless_monitor_service.h
+++ b/src/limitless/limitless_monitor_service.h
@@ -75,9 +75,11 @@ typedef struct {
  * by connecting using the ODBC API to connect and check using a query
  *
  * @param connection_string_c_str the connection string to specify the driver and server
+ * @param custom_errmsg_c_str custom error message to append error information when this method fails to check limitless
+ * @param errmsg_ptr the string which this points to will be set to an error message if this method fails to check limitless, otherwise set to NULL
  * @return True if the given connection string connects to a Limitless Cluster
  */
-bool CheckLimitlessCluster(const SQLTCHAR *connection_string_c_str, char *errmsg_out_c_str, size_t errmsg_out_size, char *custom_errmsg_c_str);
+bool CheckLimitlessCluster(const SQLTCHAR *connection_string_c_str, const char *custom_errmsg_c_str, const char **errmsg_ptr);
 
 /**
  * Increments a reference count for the given service ID, spinning a transaction router polling thread

--- a/src/limitless/limitless_monitor_service.h
+++ b/src/limitless/limitless_monitor_service.h
@@ -77,7 +77,7 @@ typedef struct {
  * @param connection_string_c_str the connection string to specify the driver and server
  * @return True if the given connection string connects to a Limitless Cluster
  */
-bool CheckLimitlessCluster(SQLHDBC hdbc);
+bool CheckLimitlessCluster(const SQLTCHAR *connection_string_c_str);
 
 /**
  * Increments a reference count for the given service ID, spinning a transaction router polling thread

--- a/src/limitless/limitless_monitor_service.h
+++ b/src/limitless/limitless_monitor_service.h
@@ -77,7 +77,7 @@ typedef struct {
  * @param connection_string_c_str the connection string to specify the driver and server
  * @return True if the given connection string connects to a Limitless Cluster
  */
-bool CheckLimitlessCluster(const SQLTCHAR *connection_string_c_str);
+bool CheckLimitlessCluster(const SQLTCHAR *connection_string_c_str, char *errmsg_out_c_str, size_t errmsg_out_size, char *custom_errmsg_c_str);
 
 /**
  * Increments a reference count for the given service ID, spinning a transaction router polling thread

--- a/src/limitless/limitless_monitor_service.h
+++ b/src/limitless/limitless_monitor_service.h
@@ -76,10 +76,11 @@ typedef struct {
  *
  * @param connection_string_c_str the connection string to specify the driver and server
  * @param custom_errmsg_c_str custom error message to append error information when this method fails to check limitless
- * @param errmsg_ptr the string which this points to will be set to an error message if this method fails to check limitless, otherwise set to NULL
+ * @param final_errmsg_c_str the final error message string if this method fails to check limitless
+ * @param final_errmsg_size the size of final_errmsg_c_str
  * @return True if the given connection string connects to a Limitless Cluster
  */
-bool CheckLimitlessCluster(const SQLTCHAR *connection_string_c_str, const char *custom_errmsg_c_str, const char **errmsg_ptr);
+bool CheckLimitlessCluster(const SQLTCHAR *connection_string_c_str, const char *custom_errmsg_c_str, char *final_errmsg_c_str, size_t final_errmsg_size);
 
 /**
  * Increments a reference count for the given service ID, spinning a transaction router polling thread

--- a/src/util/odbc_helper.cc
+++ b/src/util/odbc_helper.cc
@@ -168,8 +168,8 @@ bool OdbcHelper::FetchResults(SQLHSTMT stmt, const std::string& log_message) {
 std::string OdbcHelper::MergeDiagRecs(HDBC hdbc, const std::string &custom_errmsg) {
     std::string errmsg;
 
-    SQLTCHAR    sqlstate[OdbcHelper::SQLSTATE_LENGTH];
-    SQLTCHAR    message[OdbcHelper::MAX_MSG_LENGTH];
+    SQLTCHAR    sqlstate[SQLSTATE_LENGTH];
+    SQLTCHAR    message[MAX_MSG_LENGTH];
     SQLINTEGER  nativeerror;
     SQLSMALLINT textlen;
     SQLRETURN   ret;

--- a/src/util/odbc_helper.cc
+++ b/src/util/odbc_helper.cc
@@ -165,7 +165,7 @@ bool OdbcHelper::FetchResults(SQLHSTMT stmt, const std::string& log_message) {
     return true;
 }
 
-std::string OdbcHelper::MergeDiagRecs(HDBC hdbc, const std::string &custom_errmsg) {
+std::string OdbcHelper::MergeDiagRecs(SQLHANDLE handle, int32_t handle_type, std::string custom_errmsg) {
     std::string errmsg;
 
     SQLTCHAR    sqlstate[SQLSTATE_LENGTH];
@@ -179,7 +179,7 @@ std::string OdbcHelper::MergeDiagRecs(HDBC hdbc, const std::string &custom_errms
     do {
         recno++;
         message[0] = '\0';
-        ret = SQLGetDiagRec(SQL_HANDLE_DBC, hdbc, recno, sqlstate, &nativeerror, message, sizeof(message), &textlen);
+        ret = SQLGetDiagRec(handle_type, handle, recno, sqlstate, &nativeerror, message, sizeof(message), &textlen);
         if (SQL_SUCCEEDED(ret)) {
             std::string newmsg = StringHelper::ToString(message);
             errmsg = StringHelper::MergeStrings(errmsg, newmsg);
@@ -194,8 +194,8 @@ std::string OdbcHelper::MergeDiagRecs(HDBC hdbc, const std::string &custom_errms
 }
 
 void OdbcHelper::LogMessage(const std::string& log_message, SQLHANDLE handle, int32_t handle_type) {
-    SQLTCHAR     sqlstate[MAX_STATE_LENGTH];
-    SQLTCHAR     message[MAX_MSG_LENGTH];
+    SQLTCHAR    sqlstate[MAX_STATE_LENGTH];
+    SQLTCHAR    message[MAX_MSG_LENGTH];
     SQLINTEGER  nativeerror;
     SQLSMALLINT textlen;
     SQLRETURN   ret;

--- a/src/util/odbc_helper.cc
+++ b/src/util/odbc_helper.cc
@@ -168,7 +168,7 @@ bool OdbcHelper::FetchResults(SQLHSTMT stmt, const std::string& log_message) {
 std::string OdbcHelper::MergeDiagRecs(SQLHANDLE handle, int32_t handle_type, std::string custom_errmsg) {
     std::string errmsg;
 
-    SQLTCHAR    sqlstate[SQLSTATE_LENGTH];
+    SQLTCHAR    sqlstate[MAX_STATE_LENGTH];
     SQLTCHAR    message[MAX_MSG_LENGTH];
     SQLINTEGER  nativeerror;
     SQLSMALLINT textlen;

--- a/src/util/odbc_helper.cc
+++ b/src/util/odbc_helper.cc
@@ -166,37 +166,31 @@ bool OdbcHelper::FetchResults(SQLHSTMT stmt, const std::string& log_message) {
 }
 
 std::string OdbcHelper::MergeDiagRecs(HDBC hdbc, const std::string &custom_errmsg) {
-	std::string errmsg = "";
+    std::string errmsg;
 
-	SQLTCHAR    sqlstate[6];
-	SQLTCHAR    message[OdbcHelper::MAX_MSG_LENGTH];
-	SQLINTEGER  nativeerror;
-	SQLSMALLINT textlen;
-	SQLRETURN   ret;
-	SQLSMALLINT recno = 0;
+    SQLTCHAR    sqlstate[OdbcHelper::SQLSTATE_LENGTH];
+    SQLTCHAR    message[OdbcHelper::MAX_MSG_LENGTH];
+    SQLINTEGER  nativeerror;
+    SQLSMALLINT textlen;
+    SQLRETURN   ret;
+    SQLSMALLINT recno = 0;
 
-	// merge all error messages for the failed dbc
-	do {
-		recno++;
-		message[0] = '\0';
-		ret = SQLGetDiagRec(SQL_HANDLE_DBC, hdbc, recno, sqlstate, &nativeerror, message, sizeof(message), &textlen);
-		if (SQL_SUCCEEDED(ret)) {
+    // merge all error messages for the failed dbc
+    do {
+        recno++;
+        message[0] = '\0';
+        ret = SQLGetDiagRec(SQL_HANDLE_DBC, hdbc, recno, sqlstate, &nativeerror, message, sizeof(message), &textlen);
+        if (SQL_SUCCEEDED(ret)) {
             std::string newmsg = StringHelper::ToString(message);
-
-            if (errmsg.empty()) {
-                errmsg = newmsg;
-            } else {
-                // separate each message with a new line
-                errmsg = errmsg + '\n' + newmsg;
-            }
-		}
-	} while (ret == SQL_SUCCESS);
+            errmsg = StringHelper::MergeStrings(errmsg, newmsg);
+        }
+    } while (ret == SQL_SUCCESS);
 
     if (custom_errmsg.empty()) {
         return errmsg;
     }
 
-    return errmsg + '\n' + custom_errmsg;
+    return StringHelper::MergeStrings(errmsg, custom_errmsg);
 }
 
 void OdbcHelper::LogMessage(const std::string& log_message, SQLHANDLE handle, int32_t handle_type) {

--- a/src/util/odbc_helper.cc
+++ b/src/util/odbc_helper.cc
@@ -165,7 +165,7 @@ bool OdbcHelper::FetchResults(SQLHSTMT stmt, const std::string& log_message) {
     return true;
 }
 
-std::string OdbcHelper::MergeDiagRecs(SQLHANDLE handle, int32_t handle_type, std::string custom_errmsg) {
+std::string OdbcHelper::MergeDiagRecs(SQLHANDLE handle, int32_t handle_type, const std::string& custom_errmsg) {
     std::string errmsg;
 
     SQLTCHAR    sqlstate[MAX_STATE_LENGTH];

--- a/src/util/odbc_helper.cc
+++ b/src/util/odbc_helper.cc
@@ -108,6 +108,11 @@ bool OdbcHelper::AllocateHandle(SQLSMALLINT handle_type, SQLHANDLE input_handle,
     return true;
 }
 
+bool OdbcHelper::SetHenvToOdbc3(SQLHENV henv, const std::string& log_message) {
+    SQLRETURN rc = SQLSetEnvAttr(henv, SQL_ATTR_ODBC_VERSION, (SQLPOINTER) SQL_OV_ODBC3, 0);
+    return OdbcHelper::CheckResult(rc, log_message, henv, SQL_HANDLE_ENV);
+}
+
 bool OdbcHelper::ExecuteQuery(SQLHSTMT stmt, SQLTCHAR* query, const std::string& log_message) {
     if (SQL_NULL_HANDLE == stmt) {
         LOG(WARNING) << "Attempted to execute query using null HSTMT";

--- a/src/util/odbc_helper.cc
+++ b/src/util/odbc_helper.cc
@@ -109,7 +109,7 @@ bool OdbcHelper::AllocateHandle(SQLSMALLINT handle_type, SQLHANDLE input_handle,
 }
 
 bool OdbcHelper::SetHenvToOdbc3(SQLHENV henv, const std::string& log_message) {
-    SQLRETURN rc = SQLSetEnvAttr(henv, SQL_ATTR_ODBC_VERSION, (SQLPOINTER) SQL_OV_ODBC3, 0);
+    SQLRETURN rc = SQLSetEnvAttr(henv, SQL_ATTR_ODBC_VERSION, reinterpret_cast<SQLPOINTER>(SQL_OV_ODBC3), 0);
     return OdbcHelper::CheckResult(rc, log_message, henv, SQL_HANDLE_ENV);
 }
 

--- a/src/util/odbc_helper.h
+++ b/src/util/odbc_helper.h
@@ -28,6 +28,7 @@ class OdbcHelper {
 public:
     static const int MAX_STATE_LENGTH = 32;
     static const int MAX_MSG_LENGTH = 1024;
+    static const int SQLSTATE_LENGTH = 6;
     static SQLTCHAR *check_connection_query;
 
     static bool ConnStrConnect(SQLTCHAR* conn_str, SQLHDBC& out_conn);

--- a/src/util/odbc_helper.h
+++ b/src/util/odbc_helper.h
@@ -70,7 +70,7 @@ public:
     bool ExecuteQuery(SQLHSTMT stmt, SQLTCHAR* query, const std::string& log_message) override { return OdbcHelper::ExecuteQuery(stmt, query, log_message); };
     bool BindColumn(SQLHSTMT stmt, SQLUSMALLINT col_num, SQLSMALLINT type, SQLPOINTER dest, SQLLEN dest_size, const std::string& log_message) override { return OdbcHelper::BindColumn(stmt, col_num, type, dest, dest_size, log_message); };
     bool FetchResults(SQLHSTMT stmt, const std::string& log_message) override { return OdbcHelper::FetchResults(stmt, log_message); };
-    std::string MergeDiagRecs(SQLHANDLE handle, int32_t handle_type, std::string custom_errmsg) { return OdbcHelper::MergeDiagRecs(handle, handle_type, custom_errmsg); };
+    std::string MergeDiagRecs(SQLHANDLE handle, int32_t handle_type, std::string custom_errmsg) override { return OdbcHelper::MergeDiagRecs(handle, handle_type, custom_errmsg); };
 };
 
 #endif // ODBCHELPER_H_

--- a/src/util/odbc_helper.h
+++ b/src/util/odbc_helper.h
@@ -39,6 +39,7 @@ public:
     static bool ExecuteQuery(SQLHSTMT stmt, SQLTCHAR* query, const std::string& log_message);
     static bool BindColumn(SQLHSTMT stmt, SQLUSMALLINT col_num, SQLSMALLINT type, SQLPOINTER dest, SQLLEN dest_size, const std::string& log_message);
     static bool FetchResults(SQLHSTMT stmt, const std::string& log_message);
+    static std::string MergeDiagRecs(HDBC hdbc, const std::string &custom_errmsg);
 
 private:
     static void LogMessage(const std::string& log_message, SQLHANDLE handle, int32_t handle_type);     

--- a/src/util/odbc_helper.h
+++ b/src/util/odbc_helper.h
@@ -40,7 +40,7 @@ public:
     static bool ExecuteQuery(SQLHSTMT stmt, SQLTCHAR* query, const std::string& log_message);
     static bool BindColumn(SQLHSTMT stmt, SQLUSMALLINT col_num, SQLSMALLINT type, SQLPOINTER dest, SQLLEN dest_size, const std::string& log_message);
     static bool FetchResults(SQLHSTMT stmt, const std::string& log_message);
-    static std::string MergeDiagRecs(HDBC hdbc, const std::string &custom_errmsg);
+    static std::string MergeDiagRecs(SQLHANDLE handle, int32_t handle_type, std::string custom_errmsg);
 
 private:
     static void LogMessage(const std::string& log_message, SQLHANDLE handle, int32_t handle_type);     
@@ -57,6 +57,7 @@ public:
     virtual bool ExecuteQuery(SQLHSTMT stmt, SQLTCHAR* query, const std::string& log_message) = 0;
     virtual bool BindColumn(SQLHSTMT stmt, SQLUSMALLINT col_num, SQLSMALLINT type, SQLPOINTER dest, SQLLEN dest_size, const std::string& log_message) = 0;
     virtual bool FetchResults(SQLHSTMT stmt, const std::string& log_message) = 0;
+    virtual std::string MergeDiagRecs(SQLHANDLE handle, int32_t handle_type, std::string custom_errmsg) = 0;
 };
 
 class OdbcHelperWrapper : public IOdbcHelper {
@@ -70,6 +71,7 @@ public:
     bool ExecuteQuery(SQLHSTMT stmt, SQLTCHAR* query, const std::string& log_message) override { return OdbcHelper::ExecuteQuery(stmt, query, log_message); };
     bool BindColumn(SQLHSTMT stmt, SQLUSMALLINT col_num, SQLSMALLINT type, SQLPOINTER dest, SQLLEN dest_size, const std::string& log_message) override { return OdbcHelper::BindColumn(stmt, col_num, type, dest, dest_size, log_message); };
     bool FetchResults(SQLHSTMT stmt, const std::string& log_message) override { return OdbcHelper::FetchResults(stmt, log_message); };
+    std::string MergeDiagRecs(SQLHANDLE handle, int32_t handle_type, std::string custom_errmsg) { return OdbcHelper::MergeDiagRecs(handle, handle_type, custom_errmsg); };
 };
 
 #endif // ODBCHELPER_H_

--- a/src/util/odbc_helper.h
+++ b/src/util/odbc_helper.h
@@ -35,6 +35,7 @@ public:
     static bool CheckConnection(SQLHDBC hdbc);
     static void Cleanup(SQLHENV henv, SQLHDBC hdbc, SQLHSTMT hstmt);
     static bool AllocateHandle(SQLSMALLINT handle_type, SQLHANDLE input_handle, SQLHANDLE& output_handle, const std::string& log_message);
+    static bool SetHenvToOdbc3(SQLHENV henv, const std::string& log_message);
     static bool ExecuteQuery(SQLHSTMT stmt, SQLTCHAR* query, const std::string& log_message);
     static bool BindColumn(SQLHSTMT stmt, SQLUSMALLINT col_num, SQLSMALLINT type, SQLPOINTER dest, SQLLEN dest_size, const std::string& log_message);
     static bool FetchResults(SQLHSTMT stmt, const std::string& log_message);
@@ -50,6 +51,7 @@ public:
     virtual bool CheckConnection(SQLHDBC hdbc) = 0;
     virtual void Cleanup(SQLHENV henv, SQLHDBC hdbc, SQLHSTMT hstmt) = 0;
     virtual bool AllocateHandle(SQLSMALLINT handle_type, SQLHANDLE input_handle, SQLHANDLE& output_handle, const std::string& log_message) = 0;
+    virtual bool SetHenvToOdbc3(SQLHENV henv, const std::string& log_message) = 0;
     virtual bool ExecuteQuery(SQLHSTMT stmt, SQLTCHAR* query, const std::string& log_message) = 0;
     virtual bool BindColumn(SQLHSTMT stmt, SQLUSMALLINT col_num, SQLSMALLINT type, SQLPOINTER dest, SQLLEN dest_size, const std::string& log_message) = 0;
     virtual bool FetchResults(SQLHSTMT stmt, const std::string& log_message) = 0;
@@ -62,6 +64,7 @@ public:
     bool CheckConnection(SQLHDBC hdbc) override { return OdbcHelper::CheckConnection(hdbc); };
     void Cleanup(SQLHENV henv, SQLHDBC hdbc, SQLHSTMT hstmt) override { OdbcHelper::Cleanup(henv, hdbc, hstmt); };
     bool AllocateHandle(SQLSMALLINT handle_type, SQLHANDLE input_handle, SQLHANDLE& output_handle, const std::string& log_message) override { return OdbcHelper::AllocateHandle(handle_type, input_handle, output_handle, log_message); };
+    bool SetHenvToOdbc3(SQLHENV henv, const std::string& log_message) override {return OdbcHelper::SetHenvToOdbc3(henv, log_message); };
     bool ExecuteQuery(SQLHSTMT stmt, SQLTCHAR* query, const std::string& log_message) override { return OdbcHelper::ExecuteQuery(stmt, query, log_message); };
     bool BindColumn(SQLHSTMT stmt, SQLUSMALLINT col_num, SQLSMALLINT type, SQLPOINTER dest, SQLLEN dest_size, const std::string& log_message) override { return OdbcHelper::BindColumn(stmt, col_num, type, dest, dest_size, log_message); };
     bool FetchResults(SQLHSTMT stmt, const std::string& log_message) override { return OdbcHelper::FetchResults(stmt, log_message); };

--- a/src/util/odbc_helper.h
+++ b/src/util/odbc_helper.h
@@ -28,7 +28,6 @@ class OdbcHelper {
 public:
     static const int MAX_STATE_LENGTH = 32;
     static const int MAX_MSG_LENGTH = 1024;
-    static const int SQLSTATE_LENGTH = 6;
     static SQLTCHAR *check_connection_query;
 
     static bool ConnStrConnect(SQLTCHAR* conn_str, SQLHDBC& out_conn);

--- a/src/util/odbc_helper.h
+++ b/src/util/odbc_helper.h
@@ -64,7 +64,7 @@ public:
     bool CheckConnection(SQLHDBC hdbc) override { return OdbcHelper::CheckConnection(hdbc); };
     void Cleanup(SQLHENV henv, SQLHDBC hdbc, SQLHSTMT hstmt) override { OdbcHelper::Cleanup(henv, hdbc, hstmt); };
     bool AllocateHandle(SQLSMALLINT handle_type, SQLHANDLE input_handle, SQLHANDLE& output_handle, const std::string& log_message) override { return OdbcHelper::AllocateHandle(handle_type, input_handle, output_handle, log_message); };
-    bool SetHenvToOdbc3(SQLHENV henv, const std::string& log_message) override {return OdbcHelper::SetHenvToOdbc3(henv, log_message); };
+    bool SetHenvToOdbc3(SQLHENV henv, const std::string& log_message) override { return OdbcHelper::SetHenvToOdbc3(henv, log_message); };
     bool ExecuteQuery(SQLHSTMT stmt, SQLTCHAR* query, const std::string& log_message) override { return OdbcHelper::ExecuteQuery(stmt, query, log_message); };
     bool BindColumn(SQLHSTMT stmt, SQLUSMALLINT col_num, SQLSMALLINT type, SQLPOINTER dest, SQLLEN dest_size, const std::string& log_message) override { return OdbcHelper::BindColumn(stmt, col_num, type, dest, dest_size, log_message); };
     bool FetchResults(SQLHSTMT stmt, const std::string& log_message) override { return OdbcHelper::FetchResults(stmt, log_message); };

--- a/src/util/odbc_helper.h
+++ b/src/util/odbc_helper.h
@@ -39,7 +39,7 @@ public:
     static bool ExecuteQuery(SQLHSTMT stmt, SQLTCHAR* query, const std::string& log_message);
     static bool BindColumn(SQLHSTMT stmt, SQLUSMALLINT col_num, SQLSMALLINT type, SQLPOINTER dest, SQLLEN dest_size, const std::string& log_message);
     static bool FetchResults(SQLHSTMT stmt, const std::string& log_message);
-    static std::string MergeDiagRecs(SQLHANDLE handle, int32_t handle_type, std::string custom_errmsg);
+    static std::string MergeDiagRecs(SQLHANDLE handle, int32_t handle_type, const std::string& custom_errmsg);
 
 private:
     static void LogMessage(const std::string& log_message, SQLHANDLE handle, int32_t handle_type);     
@@ -56,7 +56,7 @@ public:
     virtual bool ExecuteQuery(SQLHSTMT stmt, SQLTCHAR* query, const std::string& log_message) = 0;
     virtual bool BindColumn(SQLHSTMT stmt, SQLUSMALLINT col_num, SQLSMALLINT type, SQLPOINTER dest, SQLLEN dest_size, const std::string& log_message) = 0;
     virtual bool FetchResults(SQLHSTMT stmt, const std::string& log_message) = 0;
-    virtual std::string MergeDiagRecs(SQLHANDLE handle, int32_t handle_type, std::string custom_errmsg) = 0;
+    virtual std::string MergeDiagRecs(SQLHANDLE handle, int32_t handle_type, const std::string& custom_errmsg) = 0;
 };
 
 class OdbcHelperWrapper : public IOdbcHelper {
@@ -70,7 +70,7 @@ public:
     bool ExecuteQuery(SQLHSTMT stmt, SQLTCHAR* query, const std::string& log_message) override { return OdbcHelper::ExecuteQuery(stmt, query, log_message); };
     bool BindColumn(SQLHSTMT stmt, SQLUSMALLINT col_num, SQLSMALLINT type, SQLPOINTER dest, SQLLEN dest_size, const std::string& log_message) override { return OdbcHelper::BindColumn(stmt, col_num, type, dest, dest_size, log_message); };
     bool FetchResults(SQLHSTMT stmt, const std::string& log_message) override { return OdbcHelper::FetchResults(stmt, log_message); };
-    std::string MergeDiagRecs(SQLHANDLE handle, int32_t handle_type, std::string custom_errmsg) override { return OdbcHelper::MergeDiagRecs(handle, handle_type, custom_errmsg); };
+    std::string MergeDiagRecs(SQLHANDLE handle, int32_t handle_type, const std::string& custom_errmsg) override { return OdbcHelper::MergeDiagRecs(handle, handle_type, custom_errmsg); };
 };
 
 #endif // ODBCHELPER_H_

--- a/src/util/string_helper.h
+++ b/src/util/string_helper.h
@@ -174,7 +174,7 @@ public:
     /**
      * Copies a string to a character array with an optional warning if it is truncated
      */
-    static void CopyToCStr(std::string str, char *arr, size_t arr_size, std::string truncated_warning) {
+    static void CopyToCStr(std::string str, char *arr, size_t arr_size, const std::string &truncated_warning) {
         if (arr == nullptr) return;
 
         if (str.size() >= arr_size) {

--- a/src/util/string_helper.h
+++ b/src/util/string_helper.h
@@ -161,6 +161,22 @@ public:
     static char ToUpper(char c) {
         return std::toupper(c);
     }
+
+    static std::string MergeStrings(const std::string &a, const std::string &b) {
+        if (a.empty() && b.empty()) {
+            return "";
+        }
+
+        if (a.empty() && !b.empty()) {
+            return b;
+        }
+
+        if (!a.empty() && b.empty()) {
+            return a;
+        }
+
+        return a + '\n' + b;
+    }
 };
 
 #endif  // STRING_HELPER_H_

--- a/src/util/string_helper.h
+++ b/src/util/string_helper.h
@@ -162,19 +162,9 @@ public:
         return std::toupper(c);
     }
 
-    static std::string MergeStrings(const std::string &a, const std::string &b) {
-        if (a.empty() && b.empty()) {
-            return "";
-        }
-
-        if (a.empty() && !b.empty()) {
-            return b;
-        }
-
-        if (!a.empty() && b.empty()) {
-            return a;
-        }
-
+    static std::string MergeStrings(std::string a, std::string b) {
+        if (a.empty()) return b;
+        if (b.empty()) return a;
         return a + '\n' + b;
     }
 };

--- a/src/util/string_helper.h
+++ b/src/util/string_helper.h
@@ -163,12 +163,25 @@ public:
     }
 
     /**
-     * Merges two strings together, separated by a comma, if both aren't empty. Otherwise, returns the non-empty string, or an empty string if both are empty.
+     * Merges two strings together, separated by a new line, if both aren't empty. Otherwise, returns the non-empty string, or an empty string if both are empty
      */
     static std::string MergeStrings(std::string a, std::string b) {
         if (a.empty()) return b;
         if (b.empty()) return a;
         return a + '\n' + b;
+    }
+
+    /**
+     * Copies a string to a character array with an optional warning if it is truncated
+     */
+    void CopyToCStr(std::string str, char *arr, size_t arr_size, std::string truncated_warning) {
+        if (arr == nullptr) return;
+
+        if (str.size() >= arr_size) {
+            str = StringHelper::MergeStrings(truncated_warning, str);
+        }
+
+        strncpy(arr, str.c_str(), arr_size);
     }
 };
 

--- a/src/util/string_helper.h
+++ b/src/util/string_helper.h
@@ -174,7 +174,7 @@ public:
     /**
      * Copies a string to a character array with an optional warning if it is truncated
      */
-    void CopyToCStr(std::string str, char *arr, size_t arr_size, std::string truncated_warning) {
+    static void CopyToCStr(std::string str, char *arr, size_t arr_size, std::string truncated_warning) {
         if (arr == nullptr) return;
 
         if (str.size() >= arr_size) {

--- a/src/util/string_helper.h
+++ b/src/util/string_helper.h
@@ -28,7 +28,7 @@
 #endif
 #include <sql.h>
 
-#include <cstring> // For narrow string functions like strlen, strcpy
+#include <cstring> // For narrow string functions like strlen, strncpy
 #include <cwchar> // For wide string functions like wcslen, wcscpy
 #include <cwctype> // For wide character functions like towupper
 #include <locale>
@@ -162,6 +162,9 @@ public:
         return std::toupper(c);
     }
 
+    /**
+     * Merges two strings together, separated by a comma, if both aren't empty. Otherwise, returns the non-empty string, or an empty string if both are empty.
+     */
     static std::string MergeStrings(std::string a, std::string b) {
         if (a.empty()) return b;
         if (b.empty()) return a;

--- a/test/unit_test/mock_objects.h
+++ b/test/unit_test/mock_objects.h
@@ -128,6 +128,7 @@ public:
     MOCK_METHOD(bool, CheckConnection, (SQLHDBC), ());
     MOCK_METHOD(void, Cleanup, (SQLHENV, SQLHDBC, SQLHSTMT), ());
     MOCK_METHOD(bool, AllocateHandle, (SQLSMALLINT, SQLHANDLE, SQLHANDLE&, const std::string&), ());
+    MOCK_METHOD(bool, SetHenvToOdbc3, (SQLHENV, const std::string&), ());
     MOCK_METHOD(bool, ExecuteQuery, (SQLHSTMT, SQLTCHAR*, const std::string&), ());
     MOCK_METHOD(bool, BindColumn, (SQLHSTMT, SQLUSMALLINT, SQLSMALLINT, SQLPOINTER, SQLLEN, const std::string&), ());
     MOCK_METHOD(bool, FetchResults, (SQLHSTMT, const std::string&), ());

--- a/test/unit_test/mock_objects.h
+++ b/test/unit_test/mock_objects.h
@@ -132,6 +132,7 @@ public:
     MOCK_METHOD(bool, ExecuteQuery, (SQLHSTMT, SQLTCHAR*, const std::string&), ());
     MOCK_METHOD(bool, BindColumn, (SQLHSTMT, SQLUSMALLINT, SQLSMALLINT, SQLPOINTER, SQLLEN, const std::string&), ());
     MOCK_METHOD(bool, FetchResults, (SQLHSTMT, const std::string&), ());
+    MOCK_METHOD(std::string, MergeDiagRecs, (SQLHANDLE handle, int32_t handle_type, std::string custom_errmsg), ());
 };
 
 class MOCK_CLUSTER_TOPOLOGY_QUERY_HELPER : public ClusterTopologyQueryHelper {

--- a/test/unit_test/mock_objects.h
+++ b/test/unit_test/mock_objects.h
@@ -132,7 +132,7 @@ public:
     MOCK_METHOD(bool, ExecuteQuery, (SQLHSTMT, SQLTCHAR*, const std::string&), ());
     MOCK_METHOD(bool, BindColumn, (SQLHSTMT, SQLUSMALLINT, SQLSMALLINT, SQLPOINTER, SQLLEN, const std::string&), ());
     MOCK_METHOD(bool, FetchResults, (SQLHSTMT, const std::string&), ());
-    MOCK_METHOD(std::string, MergeDiagRecs, (SQLHANDLE handle, int32_t handle_type, std::string custom_errmsg), ());
+    MOCK_METHOD(std::string, MergeDiagRecs, (SQLHANDLE handle, int32_t handle_type, const std::string &custom_errmsg), ());
 };
 
 class MOCK_CLUSTER_TOPOLOGY_QUERY_HELPER : public ClusterTopologyQueryHelper {


### PR DESCRIPTION
# Summary
refactor: move odbc calls into library for limitless

## Description


## Testing
Manual test, ran integration test on limitless