### PR TITLE
fix: remove logger_wrapper.h include from host_info.h

### DIFF
--- a/src/host_info.h
+++ b/src/host_info.h
@@ -21,7 +21,6 @@
 #ifdef WIN32
     #include <windows.h>
 #endif
-
 #include <sqltypes.h>
 
 #include "host_availability/host_availability_strategy.h"

--- a/src/host_selector/highest_weight_host_selector.cc
+++ b/src/host_selector/highest_weight_host_selector.cc
@@ -14,6 +14,10 @@
 
 #include "highest_weight_host_selector.h"
 
+#include <algorithm>
+#include <iterator>
+#include <stdexcept>
+
 HostInfo HighestWeightHostSelector::GetHost(std::vector<HostInfo> hosts, bool is_writer, std::unordered_map<std::string, std::string>) {
     std::vector<HostInfo> eligible_hosts;
     eligible_hosts.reserve(hosts.size());

--- a/src/host_selector/host_selector.h
+++ b/src/host_selector/host_selector.h
@@ -17,9 +17,6 @@
 
 #include "../host_info.h"
 
-#include <algorithm>
-#include <iterator>
-#include <stdexcept>
 #include <string>
 #include <unordered_map>
 #include <vector>

--- a/src/host_selector/random_host_selector.cc
+++ b/src/host_selector/random_host_selector.cc
@@ -14,7 +14,10 @@
 
 #include "random_host_selector.h"
 
+#include <algorithm>
+#include <iterator>
 #include <random>
+#include <stdexcept>
 
 HostInfo RandomHostSelector::GetHost(std::vector<HostInfo> hosts, bool is_writer,
     std::unordered_map<std::string, std::string>) {

--- a/src/host_selector/round_robin_host_selector.cc
+++ b/src/host_selector/round_robin_host_selector.cc
@@ -14,6 +14,10 @@
 
 #include "round_robin_host_selector.h"
 
+#include <algorithm>
+#include <iterator>
+#include <stdexcept>
+
 // Initialize static members
 std::mutex RoundRobinHostSelector::cache_mutex;
 SlidingCacheMap<std::string, std::shared_ptr<round_robin_property::RoundRobinClusterInfo>> RoundRobinHostSelector::round_robin_cache;


### PR DESCRIPTION
# Summary

Removes logger_wrapper.h from host_info.h and adds any necessary different includes to files.

## Description

The driver integration tests can't compile <glog/logging.h> which logger_wrapper.h includes.

However, no header code actually uses the logger, so it should just be included in .cc files instead.

## Testing

- [x] Unit tests pass
- [x] Driver integ tests pass
