### PR TITLE
feat: failover status codes

### DIFF
--- a/src/failover/failover_service.h
+++ b/src/failover/failover_service.h
@@ -92,8 +92,14 @@ typedef enum {
     AURORA_POSTGRES
 } DatabaseDialect;
 
+typedef enum {
+    FAILOVER_FAILED,
+    FAILOVER_SKIPPED,
+    FAILOVER_SUCCEED
+} FailoverStatus;
+
 typedef struct {
-    bool connection_changed;
+    FailoverStatus status;
     SQLHDBC hdbc;
 } FailoverResult;
 
@@ -153,7 +159,7 @@ public:
 #endif
     ~FailoverService();
 
-    bool Failover(SQLHDBC hdbc, const char* sql_state);
+    FailoverStatus Failover(SQLHDBC hdbc, const char* sql_state);
     HostInfo GetCurrentHost();
 
 private:

--- a/test/unit_test/failover/failover_service_test.cc
+++ b/test/unit_test/failover/failover_service_test.cc
@@ -115,7 +115,8 @@ TEST_F(FailoverServiceTest, failover_fail_wrong_state) {
         mock_topology_monitor,
         mock_odbc_helper
     );
-    EXPECT_FALSE(failover_service->Failover(hdbc, invalid_failover_sql_state));
+    EXPECT_EQ(failover_service->Failover(hdbc, invalid_failover_sql_state),
+        FAILOVER_SKIPPED);
 }
 
 TEST_F(FailoverServiceTest, failover_default_values_ro_cluster) {
@@ -157,7 +158,8 @@ TEST_F(FailoverServiceTest, failover_default_values_ro_cluster) {
         mock_topology_monitor,
         mock_odbc_helper
     );
-    EXPECT_TRUE(failover_service->Failover(hdbc, failover_sql_state));
+    EXPECT_EQ(failover_service->Failover(hdbc, failover_sql_state),
+        FAILOVER_SUCCEED);
     // TODO - Not fully testable, can't set internal return of `is_connected_to_reader()`
     // Since this is READER_OR_WRITER, it can still pass as it is able to connect
     // Failover on READER_OR_WRITER, will try to connect to readers first
@@ -196,7 +198,8 @@ TEST_F(FailoverServiceTest, failover_reader_or_writer_success) {
         mock_topology_monitor,
         mock_odbc_helper
     );
-    EXPECT_TRUE(failover_service->Failover(hdbc, failover_sql_state));
+    EXPECT_EQ(failover_service->Failover(hdbc, failover_sql_state),
+        FAILOVER_SUCCEED);
     // TODO - Not fully testable, can't set internal return of `is_connected_to_reader()`
     // Since this is READER_OR_WRITER, it can still pass as it is able to connect
     // Failover on READER_OR_WRITER, will try to connect to readers first
@@ -299,7 +302,8 @@ TEST_F(FailoverServiceTest, failover_fail_no_hosts) {
         mock_odbc_helper
     );
 
-    EXPECT_FALSE(failover_service->Failover(hdbc, failover_sql_state));
+    EXPECT_EQ(failover_service->Failover(hdbc, failover_sql_state),
+        FAILOVER_FAILED);
 }
 
 TEST_F(FailoverServiceTest, failover_strict_reader_fail_no_reader) {
@@ -334,7 +338,8 @@ TEST_F(FailoverServiceTest, failover_strict_reader_fail_no_reader) {
         mock_odbc_helper
     );
 
-    EXPECT_FALSE(failover_service->Failover(hdbc, failover_sql_state));
+    EXPECT_EQ(failover_service->Failover(hdbc, failover_sql_state),
+        FAILOVER_FAILED);
 }
 
 TEST_F(FailoverServiceTest, failover_strict_writer_fail_no_writer) {
@@ -356,5 +361,6 @@ TEST_F(FailoverServiceTest, failover_strict_writer_fail_no_writer) {
         mock_odbc_helper
     );
 
-    EXPECT_FALSE(failover_service->Failover(hdbc, failover_sql_state));
+    EXPECT_EQ(failover_service->Failover(hdbc, failover_sql_state),
+        FAILOVER_FAILED);
 }


### PR DESCRIPTION
# Summary
Adds status codes for Failover

## Description
Gives us more flexibility by having status codes for failover as not all "false" were a failure such as passing in a sql state which was not supported.

## Testing
Updated Unit Tests
Manual Test on Mac