### PR TITLE
chore: remove CheckLimitlessMonitorService method

### DIFF
--- a/src/limitless/limitless_monitor_service.cc
+++ b/src/limitless/limitless_monitor_service.cc
@@ -188,14 +188,6 @@ bool CheckLimitlessCluster(SQLHDBC hdbc) {
     return LimitlessQueryHelper::CheckLimitlessCluster(hdbc);
 }
 
-bool CheckLimitlessMonitorService(const char *service_id_c_str) {
-    std::string service_id(service_id_c_str);
-    if (service_id.empty())
-        return false;
-
-    return limitless_monitor_service.CheckService(service_id);
-}
-
 bool GetLimitlessInstance(const SQLTCHAR *connection_string_c_str, int host_port, char *service_id_c_str, size_t service_id_size, const LimitlessInstance *db_instance) {
     std::string service_id(service_id_c_str);
 

--- a/src/limitless/limitless_monitor_service.h
+++ b/src/limitless/limitless_monitor_service.h
@@ -100,13 +100,6 @@ typedef struct {
 bool CheckLimitlessCluster(SQLHDBC hdbc);
 
 /**
- * Checks if a limitless monitor service is running for the provided service ID
- * 
- * @param service_id_c_str the limitless monitor service ID to check
- */
-bool CheckLimitlessMonitorService(const char *service_id_c_str);
-
-/**
  * Increments a reference count for the given service ID, spinning a transaction router polling thread
  * if service ID is unique. Once thread is ready, the given LimitlessInstance, db_instance, will get
  * an updated server host


### PR DESCRIPTION
# Summary/Description

CheckLimitlessMonitorService isn't needed anymore as it's being removed in this [PR](https://github.com/aws/aws-pgsql-odbc/pull/115).

NOTE:
Do not merge until PR above is checked in. 

