### PR TITLE
fix: glog outputting to stderr when not initialized

### DIFF
--- a/src/util/logger_wrapper.h
+++ b/src/util/logger_wrapper.h
@@ -23,6 +23,7 @@
 
 #include <atomic>
 #include <filesystem>
+#include <mutex>
 
 namespace logger_config {
     const std::string PROGRAM_NAME = "aws-rds-odbc";
@@ -36,6 +37,12 @@ public:
 
     static void Initialize();
     static void Initialize(std::string log_location, int threshold);
+    
+    // Initialize glog with minimal settings (suppresses all output)
+    static void InitializeMinimal();
+    
+    // Check if glog has been initialized
+    static bool IsInitialized();
 
     static void Shutdown();
 
@@ -47,7 +54,10 @@ public:
 
 private:
     static void set_log_directory(const std::string& directory_path);
-    static inline std::atomic<int> logger_init_count = 0;
+    
+    static inline int logger_init_count = 0;
+    static inline std::atomic<bool> glog_initialized = false;
+    static inline std::mutex logger_mutex;
 };
 
 #endif // LOGGER_WRAPPER_H_

--- a/src/util/rds_logger_service.cc
+++ b/src/util/rds_logger_service.cc
@@ -20,6 +20,14 @@ void InitializeRdsLogger(const char* log_dir, int threshold) {
     LoggerWrapper::Initialize(log_dir, threshold);
 }
 
+void InitializeRdsLoggerMinimal() {
+    LoggerWrapper::InitializeMinimal();
+}
+
+bool IsRdsLoggerInitialized() {
+    return LoggerWrapper::IsInitialized();
+}
+
 void ShutdownRdsLogger() {
     LoggerWrapper::Shutdown();
 }

--- a/src/util/rds_logger_service.h
+++ b/src/util/rds_logger_service.h
@@ -26,6 +26,20 @@ extern "C" {
 void InitializeRdsLogger(const char* log_dir, int threshold);
 
 /**
+ * Initialize the logger with minimal settings (suppresses all output).
+ * This should be called if logging is not enabled but we want to prevent
+ * "Logging before InitGoogleLogging()" warnings.
+ */
+void InitializeRdsLoggerMinimal();
+
+/**
+ * Check if the RDS logger has been initialized.
+ * 
+ * @return true if the logger has been initialized, false otherwise.
+ */
+bool IsRdsLoggerInitialized();
+
+/**
  * Shutdown the logger for the AWS RDS ODBC library.
  */
 void ShutdownRdsLogger();


### PR DESCRIPTION
# Summary
fix: glog outputting to stderr when not initialized

## Description

## Testing

Manual testing with multiple threads. Confirmed that: 
1. Having with default value of rds_logging_enabled=0 with 100 threads connecting does not crash, nor does it output to stderr
2. Having rds_logging_enabled=1 with 100 threads does not crash and outputs it in the correct LOGDIR
3. Start a connection with rds_logging_enabled=0, closing it, and having subsequent conns with rds_logging_enabled=1 will still enable logs
4. Start a connection with rds_logging_enabled=1, closing it, and then having subsequent conns rds_logging_enabled=0 will disable logs. 
